### PR TITLE
ci: add tag-triggered release workflow producing six verified binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # scripts/build.sh already cross-compiles all six targets into dist/,
+      # stamps the version, and writes dist/checksums.txt. Do not duplicate it.
+      - run: scripts/build.sh "$GITHUB_REF_NAME"
+
+      # Asset names must stay exactly as build.sh emits them — install.sh
+      # downloads camne_${os}_${arch} and greps checksums.txt for " $BIN$".
+      - run: gh release create "$GITHUB_REF_NAME" --generate-notes dist/camne_* dist/checksums.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #5

## What

`.github/workflows/release.yml`, 27 lines, the only file added. On a `v*` tag push: checkout, setup-go from `go.mod`, `scripts/build.sh "$GITHUB_REF_NAME"`, then `gh release create` with all six binaries plus `dist/checksums.txt` and `--generate-notes`.

Two deliberate choices:

- **No goreleaser.** `scripts/build.sh` already cross-compiles all six targets, stamps `-ldflags "-s -w -X main.version=$VERSION"`, and writes `dist/checksums.txt`. The workflow calls it rather than reimplementing it.
- **`$GITHUB_REF_NAME` as a shell env var, not `${{ github.ref_name }}` interpolation.** Tag names are attacker-influenceable; this keeps them out of the generated script body.

`cmd/camne/main.go` already has `var version = "dev"` and a `--version` case, so the issue's "add one if missing" deliverable was already satisfied — no duplicate added. `scripts/build.sh` needed no changes.

## install.sh naming contract holds

`gh release create` uploads each asset under its basename, so `dist/camne_linux_amd64` becomes asset `camne_linux_amd64` — no path prefix, no mangling, no auto-tarballing. The two-space `sha256sum` separator survives, so install.sh's `grep " $BIN\$" | cut -d' ' -f1` still resolves.

The `.exe` entries are harmless: install.sh's grep anchors on `$`, so `" camne_windows_amd64$"` never matches `...amd64.exe`, and install.sh never constructs a Windows `$BIN` anyway — it exits early for non-Linux/Darwin `uname -s`.

## Verification

`go build ./... && go test ./...` — all four packages pass.

`scripts/build.sh v0.0.0-test` produced the six expected binaries plus checksums. install.sh's verification logic, replayed against all four assets it can actually request:

```
camne_linux_amd64   CONTRACT_OK
camne_linux_arm64   CONTRACT_OK
camne_darwin_amd64  CONTRACT_OK
camne_darwin_arm64  CONTRACT_OK
```

`./dist/camne_linux_amd64 --version` → `camne v0.0.0-test`

actionlint v1.7.12: exit 0, no findings (run from a scratch dir; `go.mod`/`go.sum` untouched, confirmed by `git status`).

`dist/` removed afterward; `git check-ignore` confirms `.gitignore:1:dist/`.

## Outstanding

The live end-to-end check — actually curl-piping `install.sh` against a real release produced by this workflow — cannot be done before merge, since it requires pushing a tag. **Run it once on the first `v*` tag after this lands.** Everything above is the offline contract simulation.

v0.2.0's existing assets are untouched; this fires only on new tag pushes.

## Follow-ups to file (not built, per the issue)

- `packaging: Homebrew tap for camne` — formula pointing at `camne_darwin_{amd64,arm64}` with sha256 from checksums.txt; wants a decision on org tap vs personal tap.
- `packaging: Scoop manifest for Windows` — install.sh refuses Windows today. Manifest can carry both arches via Scoop's `architecture` block, since `camne_windows_arm64.exe` already ships.

Also skipped: action SHA-pinning and a `concurrency` block. Add pinning if supply-chain policy ever demands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
