### PR TITLE
chore: add checked-in Claude Code hooks and permissions

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,47 @@
+# .claude/
+
+Checked-in Claude Code config for this repo. Any Claude session started here picks
+it up automatically. It enforces the rules in [`CLAUDE.md`](../CLAUDE.md)
+mechanically — it does not replace them.
+
+## Hooks
+
+| When | Runs | On failure |
+|------|------|------------|
+| After every `Edit`/`Write` | [`hooks/gofmt-file.sh`](hooks/gofmt-file.sh) — `gofmt -w` on the touched file, `*.go` only | exit 2, gofmt's parse error goes back to Claude |
+| When Claude tries to end the turn | [`hooks/verify.sh`](hooks/verify.sh) — `go build ./... && go test ./...` | exit 2, blocks the stop and hands back the failing output |
+
+Both are plain `/bin/sh`, no `jq`, no dependency beyond the Go toolchain. Measured
+on a 4-core box: gofmt hook ~3 ms for a non-Go file, `verify.sh` 0.4 s warm and
+1.2 s cold. Run them by hand the same way the harness does:
+
+```sh
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/abs/path/to/file.go"}}' \
+  | .claude/hooks/gofmt-file.sh
+echo '{"hook_event_name":"Stop"}' | CLAUDE_PROJECT_DIR=$PWD .claude/hooks/verify.sh
+```
+
+## Permissions
+
+`permissions.allow` covers the commands used constantly here — `go build/test/vet/fmt`,
+`gofmt`, `python3` on `dataset/` and `training/` scripts, `git status/diff/log`,
+`gh issue|pr view/list`. All read-only or repo-standard.
+
+Deliberately **not** allowlisted, so they still prompt:
+
+- Anything that fetches over the network (`curl`, `wget`, `go mod download`).
+  Constraint 4 says nothing leaves the machine; an allowlisted fetch is where that
+  starts to leak.
+- Starting `llama-server`. It binds a port and loads a multi-GB model — that is a
+  decision a human makes, not a silent one.
+- `python3 -c` and `python3` outside `dataset/` and `training/`. `-c` is arbitrary
+  code execution wearing a familiar name.
+- Anything destructive: `rm`, `git push`, `git reset --hard`.
+
+Cross-compile lines from `CLAUDE.md` (`CGO_ENABLED=0 GOOS=… go build …`) still
+prompt: a leading env assignment defeats prefix matching. That is fine, they are rare.
+
+## Personal settings
+
+`.claude/settings.local.json` is gitignored. Put your own permissions, model
+choice, and env there — never in `settings.json`, which is shared.

--- a/.claude/hooks/gofmt-file.sh
+++ b/.claude/hooks/gofmt-file.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# PostToolUse(Edit|Write): gofmt the file that was just written. No-op for everything else.
+#
+# Reads the hook payload on stdin, pulls tool_input.file_path, and stops immediately
+# unless it ends in .go. gofmt failing means Claude wrote Go that does not parse, so
+# exit 2 hands the error back to Claude instead of swallowing it.
+#
+# ponytail: grep+cut instead of a JSON parser, to avoid making jq a contributor
+# dependency in a repo whose whole point is zero setup. Ceiling: a file path
+# containing a quote or a backslash (Windows) extracts wrong — then gofmt errors
+# loudly rather than silently. Upgrade path: jq -r '.tool_input.file_path'.
+
+f=$(grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | cut -d'"' -f4)
+
+case "$f" in
+	*.go) ;;
+	*) exit 0 ;;
+esac
+
+[ -f "$f" ] || exit 0
+
+if ! out=$(gofmt -w "$f" 2>&1); then
+	echo "gofmt failed on $f:" >&2
+	echo "$out" >&2
+	exit 2
+fi

--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Stop: the repo gate. `go build ./... && go test ./...` must pass before a turn ends.
+# Exit 2 blocks the stop and hands the failure back to Claude, so a red build cannot
+# end a session quietly. Silent on success.
+
+input=$(cat)
+
+# Loop guard: harness versions that send stop_hook_active mark a stop that is already
+# a retry of this hook. Bail out there so a genuinely unfixable failure cannot spin.
+case "$input" in
+	*'"stop_hook_active":true'*) exit 0 ;;
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+if ! out=$(go build ./... 2>&1); then
+	echo "BLOCKED: go build ./... failed" >&2
+	echo "$out" >&2
+	exit 2
+fi
+
+if ! out=$(go test ./... 2>&1); then
+	echo "BLOCKED: go test ./... failed" >&2
+	echo "$out" >&2
+	exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,47 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/gofmt-file.sh",
+            "timeout": 10,
+            "statusMessage": "gofmt"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/verify.sh",
+            "timeout": 120,
+            "statusMessage": "go build && go test"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(go build *)",
+      "Bash(go test *)",
+      "Bash(go vet *)",
+      "Bash(go fmt *)",
+      "Bash(gofmt *)",
+      "Bash(python3 dataset/*)",
+      "Bash(python3 training/*)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.claude/settings.local.json


### PR DESCRIPTION
Closes #8

## What

Checked-in `.claude/` so any Claude session on this repo picks up the guardrails automatically:

- `.claude/settings.json` — PostToolUse(`Edit|Write`) → `gofmt-file.sh`; Stop → `verify.sh`; a permissions allowlist
- `.claude/hooks/gofmt-file.sh` — gofmt the file just written, no-op for non-Go
- `.claude/hooks/verify.sh` — `go build ./... && go test ./...` must pass before a turn ends
- `.claude/README.md` — what the config does
- `.gitignore` — `.claude/settings.local.json`

Schema checked against the current hooks docs rather than from memory, then verified structurally: `python3 json.load` parses, and `jq -e` on both event paths returns the two commands — so the nesting is right, not just the syntax. A settings.json with a wrong key silently does nothing, which is the failure mode worth ruling out.

## Shell scripts, and no `jq`

`.sh` files rather than JSON one-liners: a one-liner needs the payload extraction quoted inside JSON, cannot emit a readable failure, and cannot be invoked by hand for testing — which the issue requires.

Both are plain `/bin/sh` with **no `jq`**. Making a JSON parser a contributor dependency contradicts constraint 2 (zero setup), and a missing `jq` behind the usual `|| true` would silently no-op instead of failing loud. Path extraction is `grep -o | head -1 | cut -d'"' -f4`, carrying a `ponytail:` comment naming the ceiling (a path containing a quote or backslash) and the upgrade path (`jq -r '.tool_input.file_path'`).

Exit-code semantics are deliberate: PostToolUse exit 2 shows stderr to Claude (the tool already ran), Stop exit 2 blocks the stop and continues the conversation.

## Timings on a 4-core box

| Command | Cold (`go clean -testcache`) | Warm |
|---|---|---|
| `verify.sh` (build + test) | **1.203s** | 0.375s |
| `go test ./...` | 0.889s | 0.062s |
| `gofmt-file.sh`, non-Go file | ~3ms | — |

Fast enough that the full test gate stays under the 2s budget even cold — no scoping or `go vet` substitution needed.

## Hooks actually run, not asserted

- Edit payload, Go file → exit 0, file reformatted
- Write payload, non-Go file → exit 0, no-op
- Go file that does not parse → exit 2, `expected ')', found '{'` on stderr
- Clean tree, Stop → exit 0, silent
- Broken test, Stop → exit 2, `BLOCKED: go test ./... failed` plus the real `--- FAIL` block
- Broken build, Stop → exit 2, `BLOCKED: go build ./... failed` plus the compile error

Scratch files were removed and the deliberate breaks reverted; `git status --short --untracked-files=all` showed only the intended files before commit.

## Allowlist reasoning

```
Bash(go build *)  Bash(go test *)  Bash(go vet *)  Bash(go fmt *)  Bash(gofmt *)
Bash(python3 dataset/*)  Bash(python3 training/*)
Bash(git status *)  Bash(git diff *)  Bash(git log *)
Bash(gh issue view *)  Bash(gh issue list *)  Bash(gh pr view *)  Bash(gh pr list *)
```

**No network command is allowlisted at all.** Constraint 4 says nothing typed at the prompt leaves the machine, and an allowlisted fetch is exactly where that starts to leak — `curl`, `wget`, and `go mod download` still prompt.

`llama-server` is not allowlisted either: it binds a port and loads a multi-GB model, which stays a human decision.

`python3` is scoped to `dataset/` and `training/` paths specifically to exclude `python3 -c`, which is arbitrary code execution wearing a familiar name.

No `rm`, no `git push`, no `git reset`. The space-star form enforces a word boundary, and Claude Code matches each subcommand of a `&&`/`;`/`|` chain independently, so a chained `rm` is not covered by these entries.

## One line for CONTRIBUTING.md

Not added here — that file belongs to the CI PR. Suggested placement after it lands:

> This repo ships a checked-in `.claude/` config — `gofmt` runs on every Go file Claude edits, `go build ./... && go test ./...` must pass before a session ends, and the usual read-only commands are pre-approved; see [`.claude/README.md`](.claude/README.md), and keep personal overrides in the gitignored `.claude/settings.local.json`.

## Worth a second opinion

The Stop hook gates on Go build/test on **every** stop, including sessions doing only Python dataset work — unrelated Go breakage would block you there. Cheap (1.2s) but it is a policy choice, not a technical one.

## Deliberately left out

- No `PreToolUse` deny hooks — `permissions.deny` does that declaratively, and the real protection is that camne's default path never executes.
- No `SessionStart` hook injecting CLAUDE.md — it is already auto-loaded.
- No `go vet` in the Stop hook — `go test` compiles everything and already runs a vet subset.
- Cross-compile lines from CLAUDE.md still prompt: a leading env assignment defeats prefix matching. Documented in `.claude/README.md` rather than worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
