### PR TITLE
chore: adopt the toptal Go gitignore template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,35 @@
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go
+
+### camne ###
+# Cross-compile output from scripts/build.sh (six binaries + checksums.txt)
 dist/
+# Local secrets — never committed
+.env
+# Per-developer Claude Code overrides; .claude/settings.json IS committed
 .claude/settings.local.json


### PR DESCRIPTION
Replaces the two hand-written lines with the standard Go template from [toptal.com/developers/gitignore](https://www.toptal.com/developers/gitignore/api/go), keeping the repo-specific entries in their own `### camne ###` section so it is obvious which lines are ours and why:

- `dist/` — cross-compile output from `scripts/build.sh` (six binaries + `checksums.txt`)
- `.env` — local secrets
- `.claude/settings.local.json` — per-developer Claude Code overrides; `.claude/settings.json` itself stays committed

## Verification

Every tracked file was checked against the new rules — nothing already committed becomes ignored:

```
git ls-files | while read -r f; do git check-ignore -q "$f" && echo "WARNING: $f"; done
(no output)
```

`*.exe` was the entry worth checking, since `scripts/build.sh` produces `camne_windows_{amd64,arm64}.exe` — but those land in `dist/`, which is ignored anyway, so the release flow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)