### PR TITLE
docs: English repo docs, and release notes that read like a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,62 @@
 name: Release
 
+# A v* tag builds all six binaries and publishes them as a GitHub Release.
+# Heavy lifting lives in scripts/build.sh so this workflow stays a thin
+# orchestrator — the same script is what CI cross-compiles with, so the
+# release path cannot rot unnoticed.
 on:
   push:
     tags: ["v*"]
 
+# Never cancel a release mid-publish. Assets are uploaded one at a time, and a
+# half-published release is worse than a late one.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: write # create the release + upload the six binaries
 
 jobs:
   release:
+    name: Six binaries + publish release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
+      # Fail before building rather than after publishing a release named
+      # after a typo. build.sh stamps this string into `camne --version`.
+      - name: Check the tag is vMAJOR.MINOR.PATCH
+        run: |
+          case "$GITHUB_REF_NAME" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::tag '$GITHUB_REF_NAME' is not a vMAJOR.MINOR.PATCH release tag"; exit 1 ;;
+          esac
+
       # scripts/build.sh already cross-compiles all six targets into dist/,
       # stamps the version, and writes dist/checksums.txt. Do not duplicate it.
-      - run: scripts/build.sh "$GITHUB_REF_NAME"
+      - name: Build six binaries + checksums
+        run: scripts/build.sh "$GITHUB_REF_NAME"
 
+      # --generate-notes builds "What's Changed" from the PRs merged since the
+      # previous tag (grouped by .github/release.yml). --notes is PREPENDED
+      # above it as a fixed header carrying what a changelog cannot know:
+      # how to install, how to verify, and what happens on first run.
+      #
       # Asset names must stay exactly as build.sh emits them — install.sh
       # downloads camne_${os}_${arch} and greps checksums.txt for " $BIN$".
-      - run: gh release create "$GITHUB_REF_NAME" --generate-notes dist/camne_* dist/checksums.txt
+      - name: Create GitHub release + upload binaries
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEADER=$'Six static binaries — Linux, macOS and Windows on both amd64 and arm64. No runtime, no dependencies, nothing to install alongside them.\n\n**Linux / macOS:** `curl -fsSL https://raw.githubusercontent.com/officialdad/camne/main/install.sh | sh`\n**Windows:** download `camne_windows_amd64.exe` (or `camne_windows_arm64.exe`) below.\n\nEvery asset\'s SHA-256 is in `checksums.txt`. `install.sh` verifies it before installing and refuses on a mismatch.\n\nOn first run camne asks permission to download llama-server and the model (~1 GB, once). Answer anything but `y` and nothing is downloaded. Everything runs offline after that — nothing you type ever leaves the machine.\n\ncamne only prints commands, it never runs them, and dangerous ones are flagged with a BAHAYA warning first.'
+          gh release create "$GITHUB_REF_NAME" \
+            --title "camne ${GITHUB_REF_NAME#v}" \
+            --verify-tag \
+            --generate-notes \
+            --notes "$HEADER" \
+            dist/camne_* dist/checksums.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ messages say what to do next. No Go stack traces reaching the user.
 Technical terms stay English inside Malay sentences — that is how people
 actually speak.
 
+This covers what the program prints, and only that. Repo docs — README,
+CONTRIBUTING, release notes, commits, issues, PRs — are English, because their
+audience is contributors, not the person at the prompt. Malay quoted inside
+them (real CLI output, the demo queries) stays verbatim.
+
 ## Commits
 
 Conventional commits, written normally (not in the terse style used in chat):

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 [![Go](https://img.shields.io/github/go-mod/go-version/officialdad/camne)](go.mod)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-Tanya dalam BM, dapat shell command. Fully local, zero setup.
+Ask in Malay, get a shell command. Fully local, zero setup.
 
-![Demo camne: soalan BM colloquial, command keluar, banner BAHAYA, dan skrin kebenaran download kali pertama](demo/demo.gif)
+![camne demo: a colloquial Malay question, the command it prints, a BAHAYA warning, and the first-run download consent screen](demo/demo.gif)
 
 ```console
 $ camne nak buat file baru
 touch file.txt
 ```
 
-`camne` hanya tunjuk command — ia tak jalankan apa-apa.
+camne only prints the command. It never runs anything.
 
 ## Install
 
@@ -22,19 +22,22 @@ touch file.txt
 curl -fsSL https://raw.githubusercontent.com/officialdad/camne/main/install.sh | sh
 ```
 
-Installer letak binary dalam `/usr/local/bin` kalau folder tu boleh ditulis,
-kalau tak dalam `~/.local/bin` — dan ia akan beritahu kalau folder tu belum ada
-dalam `PATH` anda.
+The installer puts the binary in `/usr/local/bin` if that directory is
+writable, otherwise `~/.local/bin` — and tells you if that directory is not on
+your `PATH` yet.
 
-Windows: muat turun `camne_windows_amd64.exe` (atau `camne_windows_arm64.exe`)
-dari [Releases](https://github.com/officialdad/camne/releases).
+Windows: download `camne_windows_amd64.exe` (or `camne_windows_arm64.exe`) from
+[Releases](https://github.com/officialdad/camne/releases).
 
-## Cara guna
+## Usage
 
-Kali pertama, camne akan tanya kebenaran untuk download llama-server dan model
-(lebih kurang 1 GB, sekali je). Jawab bukan `y` — takde apa yang di-download.
-Lepas semua lengkap, semua jalan offline — soalan anda tak keluar dari mesin
-langsung.
+On first run camne asks permission to download llama-server and the model
+(about 1 GB, once). Answer anything but `y` and nothing is downloaded. Once
+everything is in place it all runs offline — your questions never leave the
+machine.
+
+The interface is Malay, because that is the point. Colloquial and rojak both
+work, and English still works too.
 
 ```console
 $ camne cari file lagi besar dari 100MB
@@ -45,25 +48,29 @@ $ camne nak delete semua file dalam /etc
 find /etc -type f -exec rm {} \;
 ```
 
-Command yang bahaya dapat banner `!! BAHAYA` — dan camne tak pernah jalankan
-apa-apa, ia hanya tunjuk.
+Dangerous commands get a `!! BAHAYA` banner — and camne never executes
+anything regardless, it only prints.
 
-Lain: `camne doctor` (semak pemasangan), `camne stop` (hentikan model dalam
-memory).
+Also: `camne doctor` (check the install), `camne stop` (shut down the model
+held in memory).
 
 ## Status
 
-Engine siap dengan model English (nl2sh-1.5b). Model Malay (colloquial +
-rojak) sedang dibangunkan — lihat [PROMPT.md](PROMPT.md) untuk pelan penuh.
+The engine works with an English model (nl2sh-1.5b). The Malay model
+(colloquial + rojak) is still in progress — see [PROMPT.md](PROMPT.md) for the
+full plan.
 
-## Build dari source
+## Build from source
 
 ```sh
-go build ./cmd/camne        # binary tempatan
-scripts/build.sh v0.1.0     # semua 6 target ke dist/ + checksums.txt
-vhs demo/demo.tape          # rakam semula demo.gif
+go build ./cmd/camne        # local binary
+scripts/build.sh v0.1.0     # all six targets into dist/ + checksums.txt
+vhs demo/demo.tape          # re-record demo.gif
 ```
 
-## Lesen
+Contributing: [CONTRIBUTING.md](CONTRIBUTING.md). The repo ships a checked-in
+`.claude/` config — see [`.claude/README.md`](.claude/README.md).
+
+## License
 
 Apache-2.0

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -1,9 +1,11 @@
-# camne demo — re-record with:  vhs demo/demo.tape   (dari root repo)
+# camne demo — re-record with:  vhs demo/demo.tape   (from the repo root)
 #
-# Perlu: vhs, ttyd, ffmpeg, Go. Tape ni build camne dari source sendiri.
-# Scene 1 dan 2 guna model yang dah ada dalam ~/.cache/camne (semak dengan
-# `camne doctor`). Scene 3 tunjuk skrin kali-pertama guna cache kosong dan
-# JAWAB TIDAK — jadi tape ni tak pernah download apa-apa.
+# Needs: vhs, ttyd, ffmpeg, Go. The tape builds camne from source itself.
+# Scenes 1 and 2 use the model already in ~/.cache/camne (check with
+# `camne doctor`). Scene 3 shows the first-run screen against an empty cache
+# and ANSWERS NO — so this tape never downloads anything.
+#
+# The typed queries stay in Malay: that is the product, not a translation gap.
 
 Output demo/demo.gif
 
@@ -15,26 +17,26 @@ Set Padding 24
 Set TypingSpeed 55ms
 Set Framerate 20
 
-# Setup (tak dirakam): build binary, prompt bersih.
+# Setup (not recorded): build the binary, clean prompt.
 Hide
 Type `export PS1="$ " PROMPT_COMMAND= ; mkdir -p /tmp/camne-demo && go build -o /tmp/camne-demo/camne ./cmd/camne && export PATH=/tmp/camne-demo:$PATH && clear`
 Enter
 Sleep 30s
 Show
 
-# 1. Soalan BM colloquial, dapat command.
+# 1. Colloquial Malay question, command comes back.
 Type "camne nak buat file baru"
 Sleep 500ms
 Enter
 Sleep 3s
 
-# 2. Command bahaya dapat banner BAHAYA. camne tetap tak jalankan apa-apa.
+# 2. A dangerous command gets the BAHAYA banner. camne still runs nothing.
 Type "camne nak delete semua file dalam /etc"
 Sleep 500ms
 Enter
 Sleep 4s
 
-# 3. Kali pertama pada mesin baru: camne tanya kebenaran sebelum download.
+# 3. First run on a new machine: camne asks permission before downloading.
 Hide
 Type `export XDG_CACHE_HOME=$(mktemp -d) && clear`
 Enter


### PR DESCRIPTION
Two things, matching how [camera-on-screen](https://github.com/officialdad/camera-on-screen/releases/tag/v0.11.2) does its releases.

## Release notes

`--generate-notes` already built the "What's Changed" list from merged PRs. What was missing is the part a changelog cannot know, so a fixed header is now prepended above it with `--notes`: the install one-liner, how `checksums.txt` verification works, what happens on first run (~1 GB, once, answer anything but `y` and nothing downloads), and that camne never executes anything.

Rendered header:

> Six static binaries — Linux, macOS and Windows on both amd64 and arm64. No runtime, no dependencies, nothing to install alongside them.
>
> **Linux / macOS:** `curl -fsSL https://raw.githubusercontent.com/officialdad/camne/main/install.sh | sh`
> **Windows:** download `camne_windows_amd64.exe` (or `camne_windows_arm64.exe`) below.
>
> Every asset's SHA-256 is in `checksums.txt`. `install.sh` verifies it before installing and refuses on a mismatch.
>
> On first run camne asks permission to download llama-server and the model (~1 GB, once). Answer anything but `y` and nothing is downloaded. Everything runs offline after that — nothing you type ever leaves the machine.
>
> camne only prints commands, it never runs them, and dangerous ones are flagged with a BAHAYA warning first.

Also picked up from the reference workflow:

- `--verify-tag`, and a `camne X.Y.Z` title rather than the bare tag
- a `vMAJOR.MINOR.PATCH` check that fails **before** building, so a typo'd tag cannot reach a published release
- `concurrency: cancel-in-progress: false` — assets upload one at a time, and a half-published release is worse than a late one
- `timeout-minutes: 15`

Not added: `.github/release.yml` changelog grouping. It matches on PR **labels**, and PRs here are unlabeled, so every entry would fall into the catch-all. The reference repo's notes are a flat list for the same reason.

## English docs

README and the demo tape comments were Malay; `CONTRIBUTING.md` already was not. Repo docs address contributors, not the person at the prompt.

**What deliberately stays Malay** is what the program prints — the README's `console` blocks quote real CLI output verbatim, and the tape's typed queries (`camne nak buat file baru`) are the product itself, not an untranslated string. `CLAUDE.md`'s "User-facing text" rule now states which is which, so this cannot quietly drift back. Constraint 1 is untouched: no CLI string changed, and the demo GIF still shows a Malay session.

## Verification

- `actionlint` on `release.yml`: exit 0, no findings
- The `$'...'` header was extracted from the committed file and rendered through `bash` to confirm the escapes survive — `\'` yields `asset's`, `\n\n` yields real paragraph breaks
- `${GITHUB_REF_NAME#v}` → `camne 0.3.0` for tag `v0.3.0`
- No Go code touched; `go.mod`/`go.sum` untouched

The tag guard and the notes header cannot be fully exercised until a real `v*` tag is pushed — same outstanding live check already noted on #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)