### PR TITLE
feat: check for a newer release and offer to install it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ dist/
 .env
 # Per-developer Claude Code overrides; .claude/settings.json IS committed
 .claude/settings.local.json
+# Agent worktrees created by Claude Code; each is a checkout, never content
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -70,8 +70,14 @@ sent through `cat` comes back with no colour, which is what any program reading
 camne's output would see. `NO_COLOR` or `TERM=dumb` turns colour off
 everywhere.
 
-Two other commands: `camne doctor` checks the install, `camne stop` shuts down
-the model held in memory.
+Three other commands: `camne doctor` checks the install, `camne stop` shuts down
+the model held in memory, and `camne update` installs the newest release.
+
+Once a day, after it has printed an answer, camne asks GitHub whether a newer
+release exists and offers to install it — nothing is downloaded or replaced
+until you answer the prompt. The check sends nothing but that question, never
+runs before the answer, and is skipped entirely when camne's output is piped
+somewhere.
 
 ## Build from source
 

--- a/cmd/camne/color.go
+++ b/cmd/camne/color.go
@@ -47,9 +47,14 @@ func enabled(w io.Writer) bool {
 		return false
 	}
 	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
+	return ok && isTTY(f)
+}
+
+// isTTY reports whether f is a character device, which is the portable
+// stand-in for "a person is on the other end of this". Colour asks it, and so
+// does the update prompt — one check, so the two can never disagree about
+// whether camne is being piped somewhere.
+func isTTY(f *os.File) bool {
 	fi, err := f.Stat()
 	return err == nil && fi.Mode()&os.ModeCharDevice != 0
 }

--- a/cmd/camne/main.go
+++ b/cmd/camne/main.go
@@ -41,8 +41,12 @@ func main() {
 		code = run(strings.Join(args, " "))
 	}
 	// Only now, with the answer already printed, does camne look at the
-	// network for a newer release (constraint 3).
-	offerUpdate()
+	// network for a newer release (constraint 3) — and only if that answer
+	// worked. Someone whose command just failed is owed the error, not an
+	// offer to install a different version of the thing that failed.
+	if code == 0 {
+		offerUpdate()
+	}
 	os.Exit(code)
 }
 

--- a/cmd/camne/main.go
+++ b/cmd/camne/main.go
@@ -27,18 +27,23 @@ func main() {
 		usage()
 		os.Exit(1)
 	}
+	code := 0
 	switch args[0] {
 	case "--version", "-v":
 		fmt.Println("camne " + version)
-		return
 	case "doctor":
 		doctor()
-		return
 	case "stop":
 		stop()
-		return
+	case "update":
+		os.Exit(update()) // asked for explicitly: no offer, no throttle
+	default:
+		code = run(strings.Join(args, " "))
 	}
-	os.Exit(run(strings.Join(args, " ")))
+	// Only now, with the answer already printed, does camne look at the
+	// network for a newer release (constraint 3).
+	offerUpdate()
+	os.Exit(code)
 }
 
 // run answers one query end to end. Errors from the packages below are
@@ -151,6 +156,7 @@ Contoh:  camne nak buat file baru
 
 Lain:    camne doctor   — semak apa yang dah dipasang
          camne stop     — hentikan model yang duduk dalam memory
+         camne update   — check for a newer camne and install it
 
 camne hanya tunjuk command — ia tak jalankan apa-apa.
 `)

--- a/cmd/camne/update.go
+++ b/cmd/camne/update.go
@@ -1,0 +1,258 @@
+package main
+
+// Self-update. camne notices a newer release and OFFERS it — the binary is
+// only replaced after the user answers the prompt (constraint 5).
+//
+// The check runs after the answer has already been printed, never in front of
+// it (constraint 3), at most once per 24 hours, and sends nothing but a plain
+// GET of the releases API — no query text, no telemetry (constraint 4).
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/officialdad/camne/internal/provision"
+)
+
+const (
+	repo          = "officialdad/camne"
+	latestAPI     = "https://api.github.com/repos/" + repo + "/releases/latest"
+	releaseBase   = "https://github.com/" + repo + "/releases/download/"
+	checkInterval = 24 * time.Hour
+)
+
+// One shared client so the check can never hang a run: a slow or captive
+// network costs 5 s, once a day, after the answer is already on screen.
+var updateClient = &http.Client{Timeout: 5 * time.Second}
+
+// offerUpdate is the automatic path, called after every command has finished
+// printing. Everything about it is silent on failure — a flaky network must
+// never make a normal camne run look broken.
+func offerUpdate() {
+	// A previous Windows update parked the running binary aside; this is the
+	// later run that gets to delete it.
+	if runtime.GOOS == "windows" {
+		if self, err := os.Executable(); err == nil {
+			os.Remove(self + ".old")
+		}
+	}
+	stamp, err := stampPath()
+	if err != nil {
+		return
+	}
+	tty := isTTY(os.Stdin) && isTTY(os.Stdout) && isTTY(os.Stderr)
+	if !shouldCheck(version, stamp, tty, time.Now()) {
+		return
+	}
+	// Stamp before asking, not after: a GitHub outage must not turn into a
+	// request on every single invocation.
+	touch(stamp)
+
+	tag, err := latestTag(latestAPI)
+	if err != nil || tag == version {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\nA newer camne is available: %s (you have %s)\n", tag, version)
+	fmt.Fprint(os.Stderr, "Update now? [y/N] ")
+	var answer string
+	fmt.Fscanln(os.Stdin, &answer) // a bare Enter leaves answer empty, which is "no"
+	if !strings.EqualFold(strings.TrimSpace(answer), "y") && !strings.EqualFold(strings.TrimSpace(answer), "yes") {
+		fmt.Fprintf(os.Stderr, "Ok, staying on %s. Run `camne update` whenever you want it.\n", version)
+		return
+	}
+	if err := selfUpdate(tag); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+// update is `camne update`: same job, no prompt and no throttle. Typing the
+// command IS the consent, so there is nothing left to ask.
+func update() int {
+	if version == "dev" {
+		fmt.Fprintln(os.Stderr, "This camne was built locally, so there is no version to compare against.")
+		fmt.Fprintln(os.Stderr, "Install a released camne first if you want it to update itself:")
+		fmt.Fprintln(os.Stderr, "  curl -fsSL https://raw.githubusercontent.com/"+repo+"/main/install.sh | sh")
+		return 1
+	}
+	tag, err := latestTag(latestAPI)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not reach GitHub to check for a newer camne.")
+		fmt.Fprintln(os.Stderr, "Check your internet connection and try again.")
+		return 1
+	}
+	if stamp, err := stampPath(); err == nil {
+		touch(stamp)
+	}
+	if tag == version {
+		fmt.Println("camne " + version + " is already the newest version.")
+		return 0
+	}
+	if err := selfUpdate(tag); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// shouldCheck is every skip rule in one place. A locally built binary has no
+// meaningful tag to compare, a check inside the last 24 h is enough, and a
+// piped camne must behave exactly as it did before — `camne ... | sh` is
+// normal usage, and prompting into a pipeline would interleave the prompt with
+// the command the shell is running.
+func shouldCheck(ver, stamp string, tty bool, now time.Time) bool {
+	if ver == "dev" || !tty {
+		return false
+	}
+	fi, err := os.Stat(stamp)
+	return err != nil || now.Sub(fi.ModTime()) >= checkInterval
+}
+
+// stampPath is the throttle file. There is no format and nothing to parse —
+// the mtime is the whole state.
+func stampPath() (string, error) {
+	d, err := provision.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "update-check"), nil
+}
+
+func touch(path string) {
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	if f, err := os.Create(path); err == nil {
+		f.Close()
+	}
+}
+
+// latestTag reads the tag name of the newest release. The URL is an argument
+// so tests can point it at an httptest server instead of the network.
+func latestTag(apiURL string) (string, error) {
+	body, err := fetch(apiURL)
+	if err != nil {
+		return "", err
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return "", fmt.Errorf("could not read GitHub's reply: %w", err)
+	}
+	if rel.TagName == "" {
+		return "", fmt.Errorf("GitHub's reply has no release tag in it")
+	}
+	return rel.TagName, nil
+}
+
+// fetch GETs a small text resource. The limit is there because the response is
+// untrusted input: a 1 MB cap on a few-KB document.
+func fetch(url string) ([]byte, error) {
+	resp, err := updateClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub answered HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+// assetName is the release file for a platform, matching scripts/build.sh
+// byte for byte. Change one and the other stops working.
+func assetName(goos, goarch string) string {
+	n := "camne_" + goos + "_" + goarch
+	if goos == "windows" {
+		n += ".exe"
+	}
+	return n
+}
+
+// sumFor pulls one asset's sha256 out of a `sha256sum` listing. That hash is
+// what provision.Download verifies against, so a missing or wrong line has to
+// be an error, never a silently skipped check.
+func sumFor(checksums, asset string) (string, error) {
+	for _, line := range strings.Split(checksums, "\n") {
+		f := strings.Fields(line)
+		// "<hash>  name", or "<hash> *name" from sha256sum's binary mode.
+		if len(f) == 2 && strings.TrimPrefix(f[1], "*") == asset {
+			return f[0], nil
+		}
+	}
+	return "", fmt.Errorf("this release has no %s build (%s is missing from checksums.txt) — download camne by hand from https://github.com/%s/releases", runtime.GOOS+"/"+runtime.GOARCH, asset, repo)
+}
+
+// selfUpdate downloads the release binary and puts it where this one is.
+//
+// The download, the sha256 check and the atomic rename are provision.Download,
+// unchanged: it verifies BEFORE the rename and deletes the file on a mismatch,
+// so nothing unverified can ever end up at the destination. No verification
+// logic is repeated here.
+func selfUpdate(tag string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not work out where camne is installed, so nothing was changed — reinstall with install.sh instead: %w", err)
+	}
+	// An installer may have left a symlink; replace what it points at.
+	if resolved, err := filepath.EvalSymlinks(self); err == nil {
+		self = resolved
+	}
+	asset := assetName(runtime.GOOS, runtime.GOARCH)
+	sums, err := fetch(releaseBase + tag + "/checksums.txt")
+	if err != nil {
+		return fmt.Errorf("could not download the checksum list for %s, so nothing was changed — try again later: %w", tag, err)
+	}
+	want, err := sumFor(string(sums), asset)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Downloading camne %s (%s/%s)...\n", tag, runtime.GOOS, runtime.GOARCH)
+	// Download next to the binary being replaced: same filesystem, so the
+	// rename below is atomic, and a directory camne cannot write to fails here
+	// rather than after a pointless download.
+	staged := self + ".new"
+	if err := provision.Download(releaseBase+tag+"/"+asset, staged, want); err != nil {
+		return fmt.Errorf("%w\ncamne was not changed. You can also reinstall with install.sh", err)
+	}
+	if err := os.Chmod(staged, 0o755); err != nil {
+		os.Remove(staged)
+		return fmt.Errorf("could not make the new camne runnable, so nothing was changed: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "Checksum ok.")
+	if err := replaceSelf(staged, self); err != nil {
+		os.Remove(staged)
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Done — camne %s.\n", tag)
+	return nil
+}
+
+// replaceSelf moves staged over the running binary at self.
+func replaceSelf(staged, self string) error {
+	if runtime.GOOS == "windows" {
+		// Windows will not let a running .exe be overwritten, but it will let
+		// it be renamed. Park it, move the new one in, and delete the parked
+		// copy on a later run (see offerUpdate).
+		parked := self + ".old"
+		os.Remove(parked)
+		if err := os.Rename(self, parked); err != nil {
+			return fmt.Errorf("could not move the running camne aside, so nothing was changed — close any other camne windows and try again: %w", err)
+		}
+		if err := os.Rename(staged, self); err != nil {
+			os.Rename(parked, self) // put the working one back
+			return fmt.Errorf("could not put the new camne in place, so the old one was restored — try again: %w", err)
+		}
+		return nil
+	}
+	if err := os.Rename(staged, self); err != nil {
+		return fmt.Errorf("could not replace %s, so nothing was changed — you may need to run this with sudo: %w", self, err)
+	}
+	return nil
+}

--- a/cmd/camne/update_test.go
+++ b/cmd/camne/update_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// latestTag talks to httptest, never to GitHub: the test suite must not need a
+// network, and a rate-limited API would make it flaky.
+func TestLatestTag(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"a normal release", 200, `{"tag_name":"v0.4.0","name":"camne 0.4.0"}`, "v0.4.0"},
+		{"fields camne does not care about", 200, `{"assets":[{"name":"camne_linux_amd64"}],"tag_name":"v1.2.3"}`, "v1.2.3"},
+		{"malformed body", 200, `{"tag_name": `, ""},
+		{"not JSON at all", 200, `<html>502 Bad Gateway</html>`, ""},
+		{"empty body", 200, ``, ""},
+		{"no tag in the reply", 200, `{"name":"camne"}`, ""},
+		{"rate limited", 403, `{"message":"API rate limit exceeded"}`, ""},
+		{"nothing released yet", 404, `{"message":"Not Found"}`, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+			got, err := latestTag(srv.URL)
+			if got != tt.want {
+				t.Errorf("latestTag() = %q, want %q", got, tt.want)
+			}
+			if (err != nil) != (tt.want == "") {
+				t.Errorf("latestTag() err = %v, want error: %v", err, tt.want == "")
+			}
+		})
+	}
+}
+
+// An unreachable server must be an error, not a hang and not a crash.
+func TestLatestTagUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	if _, err := latestTag(url); err == nil {
+		t.Error("latestTag() on a closed server = nil error, want an error")
+	}
+}
+
+const checksums = `936ce04d98abe2a977e9dd2ff92659bb96947e136acee8f2bc3e21d8eaebbf23  camne_linux_amd64
+95da1a0f7538340f625b0301593ee63c046ec0a155c74f21444ea4d43bca79a1  camne_linux_arm64
+6ffd9e0b9b2e3ab6ccfba332a74b968b0fef891f01bd4747d3d75bc7393877ea *camne_windows_amd64.exe
+`
+
+func TestSumFor(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		asset string
+		want  string
+	}{
+		{"present", "camne_linux_amd64", "936ce04d98abe2a977e9dd2ff92659bb96947e136acee8f2bc3e21d8eaebbf23"},
+		{"a later line", "camne_linux_arm64", "95da1a0f7538340f625b0301593ee63c046ec0a155c74f21444ea4d43bca79a1"},
+		{"binary-mode asterisk", "camne_windows_amd64.exe", "6ffd9e0b9b2e3ab6ccfba332a74b968b0fef891f01bd4747d3d75bc7393877ea"},
+		{"arch not in this release", "camne_freebsd_riscv64", ""},
+		{"a prefix of a real name matches nothing", "camne_linux_amd", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sumFor(checksums, tt.asset)
+			if got != tt.want {
+				t.Errorf("sumFor(%q) = %q, want %q", tt.asset, got, tt.want)
+			}
+			if (err != nil) != (tt.want == "") {
+				t.Errorf("sumFor(%q) err = %v, want error: %v", tt.asset, err, tt.want == "")
+			}
+		})
+	}
+	if _, err := sumFor("", "camne_linux_amd64"); err == nil {
+		t.Error("sumFor on an empty listing = nil error, want an error — an unverifiable download must never proceed")
+	}
+}
+
+// These names are also what scripts/build.sh writes and what install.sh greps
+// for. If this test changes, those two change with it.
+func TestAssetName(t *testing.T) {
+	for _, tt := range []struct{ goos, goarch, want string }{
+		{"linux", "amd64", "camne_linux_amd64"},
+		{"linux", "arm64", "camne_linux_arm64"},
+		{"darwin", "amd64", "camne_darwin_amd64"},
+		{"darwin", "arm64", "camne_darwin_arm64"},
+		{"windows", "amd64", "camne_windows_amd64.exe"},
+		{"windows", "arm64", "camne_windows_arm64.exe"},
+	} {
+		if got := assetName(tt.goos, tt.goarch); got != tt.want {
+			t.Errorf("assetName(%q, %q) = %q, want %q", tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+}
+
+func TestShouldCheck(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+
+	fresh := filepath.Join(dir, "fresh")
+	touch(fresh)
+	os.Chtimes(fresh, now.Add(-time.Hour), now.Add(-time.Hour))
+
+	stale := filepath.Join(dir, "stale")
+	touch(stale)
+	os.Chtimes(stale, now.Add(-25*time.Hour), now.Add(-25*time.Hour))
+
+	missing := filepath.Join(dir, "never-checked")
+
+	for _, tt := range []struct {
+		name  string
+		ver   string
+		stamp string
+		tty   bool
+		want  bool
+	}{
+		{"released binary, never checked, on a terminal", "v0.3.1", missing, true, true},
+		{"released binary, last check 25 h ago", "v0.3.1", stale, true, true},
+		{"last check 1 h ago", "v0.3.1", fresh, true, false},
+		{"locally built binary", "dev", missing, true, false},
+		{"piped, so no prompt is possible", "v0.3.1", missing, false, false},
+		{"piped and stale", "v0.3.1", stale, false, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldCheck(tt.ver, tt.stamp, tt.tty, now); got != tt.want {
+				t.Errorf("shouldCheck(%q, tty=%v) = %v, want %v", tt.ver, tt.tty, got, tt.want)
+			}
+		})
+	}
+
+	// touch on an existing stamp has to move the mtime forward, or the
+	// throttle would only ever work once.
+	touch(fresh)
+	if !shouldCheck("v0.3.1", fresh, true, now.Add(48*time.Hour)) {
+		t.Error("shouldCheck 48 h after a touch = false, want true")
+	}
+	if shouldCheck("v0.3.1", fresh, true, time.Now()) {
+		t.Error("shouldCheck right after a touch = true, want false — the throttle did not record the check")
+	}
+}


### PR DESCRIPTION
Closes #24.

camne notices a newer release and **offers** it. It never replaces itself on its own.

```
$ camne make a new file
touch file.txt

A newer camne is available: v0.4.0 (you have v0.3.1)
Update now? [y/N]
```

`camne update` does the same thing on demand — typing the command is the consent, so there is no prompt and no throttle.

## How the six constraints are kept

- **3 (warm answer < 1.5 s)** — the check runs *after* the answer is printed, never in front of it, and at most once per 24 h.
- **4 (nothing leaves the machine)** — a plain GET of the releases API. No query text, no telemetry. The throttle file is stamped *before* the request, so a GitHub outage cannot turn into a request on every run.
- **5 (nothing executes without consent)** — the binary is replaced only after the prompt is answered `y`.

The check is skipped entirely, with no HTTP call at all, when the binary is a local `dev` build, when the last check was under 24 h ago, or when any of stdin/stdout/stderr is not a terminal. That last rule is why `camne ... | sh` behaves exactly as it did before: prompting into a pipeline would interleave the prompt with the command the shell is running.

## Verification is reused, not rewritten

`selfUpdate` hands the download to `provision.Download`, which already resumes, verifies sha256 **before** the atomic rename, and deletes the file on mismatch. No verification logic is repeated. `sumFor` errors when the running platform is absent from `checksums.txt` rather than skipping the check.

Two details worth a reviewer's eye:

- The download is staged at `<self>.new`, next to the binary being replaced, so the rename is atomic and a read-only `/usr/local/bin` fails *before* the download instead of after it.
- Symlinks are resolved first, so an installer's symlink is not clobbered with a regular file.
- Windows cannot overwrite a running `.exe`, so the old one is parked at `.old` and deleted on a later run.

## Also here

`.claude/worktrees/` added to `.gitignore` — agent worktrees are checkouts of this repository, and committing one nests the tree inside itself.

## Tests

Table-driven, no network — `latestTag` takes a URL so `httptest` covers it. Tag parse, checksum lookup, asset name per GOOS/GOARCH, and every skip rule.

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/officialdad/camne/cmd/camne	0.010s
ok  	github.com/officialdad/camne/internal/engine	0.607s
ok  	github.com/officialdad/camne/internal/provision	0.012s
ok  	github.com/officialdad/camne/internal/safety	0.448s
```

Cross-compiles clean for windows/amd64 and darwin/arm64.

## Note on language

New strings here are English, ahead of #25, which converts the rest of camne's output and updates CLAUDE.md's *User-facing text* section. Until #25 lands the output is mixed — the new `camne update` line sits in an otherwise Malay `usage()` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
