### PR TITLE
feat: print every user-facing string in English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Violating any of these means the change is wrong, not the constraint.
 2. Zero setup — no `pipx`, no Ollama, no separate `llama-server` install, no compiler on the user's machine.
 3. Runs on 4 cores / 8 GB / no GPU. Warm answer < 1.5 s, cold start < 5 s, RSS < 2.5 GB.
 4. Nothing typed at the prompt leaves the machine. No telemetry.
-5. Nothing executes without explicit consent. `BAHAYA` never auto-runs.
+5. Nothing executes without explicit consent. camne prints the command and stops there; a command the safety checker flags is still only printed.
 6. Linux, macOS, Windows × amd64, arm64.
 
 ## Stack
@@ -108,16 +108,17 @@ No model change merges without numbers. Not examples, numbers.
 
 ## User-facing text
 
-Malay, colloquial, aimed at someone who has never used a terminal. Error
-messages say what to do next. No Go stack traces reaching the user.
+English, plain, aimed at someone who has never used a terminal. Error messages
+say what to do next. No Go stack traces reaching the user.
 
-Technical terms stay English inside Malay sentences — that is how people
-actually speak.
+Output is English; input is not. Colloquial Malay in, rojak in, English in —
+`camne nak buat file baru` still works, camne just answers in English
+(issue #25). Do not "fix" a printed string back to Malay.
 
 This covers what the program prints, and only that. Repo docs — README,
-CONTRIBUTING, release notes, commits, issues, PRs — are English, because their
-audience is contributors, not the person at the prompt. Malay quoted inside
-them (real CLI output, the demo queries) stays verbatim.
+CONTRIBUTING, release notes, commits, issues, PRs — are English too, because
+their audience is contributors, not the person at the prompt. Malay quoted
+inside them (the demo queries, real CLI input) stays verbatim.
 
 ## Commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ A change that violates one of these is wrong; the constraint is not.
 2. Zero setup — no `pipx`, no Ollama, no separate `llama-server` install, no compiler on the user's machine.
 3. Runs on 4 cores / 8 GB / no GPU. Warm answer < 1.5 s, cold start < 5 s, RSS < 2.5 GB.
 4. Nothing typed at the prompt leaves the machine. No telemetry.
-5. Nothing executes without explicit consent. `BAHAYA` never auto-runs.
+5. Nothing executes without explicit consent. camne prints the command and stops there; a command the safety checker flags is still only printed.
 6. Linux, macOS, Windows × amd64, arm64.
 
 ## Before you open a PR
@@ -43,9 +43,10 @@ A change that violates one of these is wrong; the constraint is not.
 - Touching `internal/safety`? Read the audit notes in `CLAUDE.md` first. Those
   tests *are* the audit — do not weaken them.
 - Model or dataset change? Numbers, not examples. See `CLAUDE.md`.
-- User-facing text is colloquial Malay with technical terms left in English
-  (*file*, *folder*, *server*). Error messages say what to do next. A linter
-  does not get to reword them.
+- User-facing text is plain English, aimed at someone who has never used a
+  terminal. Error messages say what to do next. A linter does not get to
+  reword them. Input stays multilingual: colloquial Malay, rojak and English
+  all have to keep working.
 
 ## Commits
 

--- a/cmd/camne/install.go
+++ b/cmd/camne/install.go
@@ -29,7 +29,7 @@ func ensureProvisioned(st provision.Status) bool {
 	if !st.ModelOK {
 		total += provision.ModelSize
 	}
-	fmt.Fprintf(os.Stderr, "camne tengah setup sendiri — download %d MB (sekali je, lepas ni semua jalan offline):\n", total/1_000_000)
+	fmt.Fprintf(os.Stderr, "camne is setting itself up — downloading %d MB (once only; after this it all works offline):\n", total/1_000_000)
 	if !st.ServerOK {
 		fmt.Fprintf(os.Stderr, "  llama-server  %d MB\n", asset.Size/1_000_000)
 	}
@@ -37,7 +37,7 @@ func ensureProvisioned(st provision.Status) bool {
 		fmt.Fprintf(os.Stderr, "  model         %d MB\n", provision.ModelSize/1_000_000)
 	}
 	if st.LibcNote != "" {
-		fmt.Fprintln(os.Stderr, "Perhatian: "+st.LibcNote)
+		fmt.Fprintln(os.Stderr, "Heads up: "+st.LibcNote)
 	}
 	if !st.ServerOK {
 		if err := installServer(asset, st.ServerPath); err != nil {
@@ -46,7 +46,7 @@ func ensureProvisioned(st provision.Status) bool {
 		}
 	}
 	if !st.ModelOK {
-		fmt.Fprintln(os.Stderr, "Download model...")
+		fmt.Fprintln(os.Stderr, "Downloading the model...")
 		if err := withProgress(st.ModelPath+".part", provision.ModelSize, func() error {
 			return provision.Download(provision.ModelURL, st.ModelPath, provision.ModelSHA256)
 		}); err != nil {
@@ -54,7 +54,7 @@ func ensureProvisioned(st provision.Status) bool {
 			return false
 		}
 	}
-	fmt.Fprintln(os.Stderr, "Siap — semua dah lengkap.")
+	fmt.Fprintln(os.Stderr, "Done — everything is ready.")
 	return true
 }
 
@@ -67,7 +67,7 @@ func installServer(asset provision.Asset, serverPath string) error {
 		return err
 	}
 	archive := filepath.Join(cacheDir, "downloads", asset.Name)
-	fmt.Fprintln(os.Stderr, "Download llama-server...")
+	fmt.Fprintln(os.Stderr, "Downloading llama-server...")
 	if err := withProgress(archive+".part", asset.Size, func() error {
 		return provision.Download(asset.URL(), archive, asset.SHA256)
 	}); err != nil {
@@ -96,7 +96,7 @@ func installServer(asset provision.Asset, serverPath string) error {
 	os.Remove(archive)
 	// The layout assumption above is upstream's packaging, not ours: verify.
 	if _, err := os.Stat(serverPath); err != nil {
-		return fmt.Errorf("unpack siap tapi llama-server tak jumpa kat tempat sepatutnya — padam folder %s lepas tu cuba lagi", filepath.Dir(serverPath))
+		return fmt.Errorf("unpacking finished but llama-server is not where it should be — delete the folder %s, then run camne again", filepath.Dir(serverPath))
 	}
 	return nil
 }

--- a/cmd/camne/main.go
+++ b/cmd/camne/main.go
@@ -51,7 +51,7 @@ func main() {
 }
 
 // run answers one query end to end. Errors from the packages below are
-// already colloquial Malay, so they are printed as-is.
+// already written for the person at the prompt, so they are printed as-is.
 func run(query string) int {
 	st, err := provision.GetStatus()
 	if err != nil {
@@ -69,7 +69,7 @@ func run(query string) int {
 		return 1
 	}
 	if cold {
-		fmt.Fprintln(os.Stderr, "Sekejap ya — model tengah load. Soalan pertama je yang lambat sikit.")
+		fmt.Fprintln(os.Stderr, "One moment — the model is loading. Only the first question is this slow.")
 	}
 	if err := cli.WaitReady(2 * time.Minute); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -121,9 +121,9 @@ func stop() {
 		os.Exit(1)
 	}
 	if stopped {
-		fmt.Println("Ok, llama-server dah dihentikan.")
+		fmt.Println("Ok, llama-server has been shut down.")
 	} else {
-		fmt.Println("Takde llama-server yang tengah jalan pun.")
+		fmt.Println("There was no llama-server running.")
 	}
 }
 
@@ -132,44 +132,44 @@ func stop() {
 func doctor() {
 	st, err := provision.GetStatus()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err) // provision errors are already in Malay
+		fmt.Fprintln(os.Stderr, err) // provision errors are already written for the user
 		os.Exit(1)
 	}
 	mark := func(ok bool) string {
 		if ok {
-			return "[ada]   "
+			return "[found]   "
 		}
-		return "[tiada] "
+		return "[missing] "
 	}
-	fmt.Println("camne doctor — semak apa yang camne perlukan")
+	fmt.Println("camne doctor — what camne needs, and what it already has")
 	fmt.Println()
 	fmt.Println(mark(st.ServerOK) + "llama-server : " + st.ServerPath)
-	fmt.Printf("%smodel        : %s (lebih kurang %d MB)\n",
+	fmt.Printf("%smodel        : %s (about %d MB)\n",
 		mark(st.ModelOK), st.ModelPath, provision.ModelSize/1_000_000)
 	if st.LibcNote != "" {
 		fmt.Println()
-		fmt.Println("Perhatian: " + st.LibcNote)
+		fmt.Println("Heads up: " + st.LibcNote)
 	}
 	fmt.Println()
 	if st.ServerOK && st.ModelOK {
-		fmt.Println("Semua lengkap — camne sedia untuk digunakan.")
+		fmt.Println("All set — camne is ready to use.")
 		return
 	}
-	fmt.Println("Taip je soalan anda — camne download sendiri apa yang tiada dulu,")
-	fmt.Println("lepas tu terus jawab.")
+	fmt.Println("Just type your question — camne downloads whatever is missing")
+	fmt.Println("first, then answers.")
 }
 
 func usage() {
-	fmt.Fprint(os.Stderr, `camne — tanya dalam BM, dapat shell command.
+	fmt.Fprint(os.Stderr, `camne — ask in plain Malay or English, get a shell command.
 
-Guna:    camne <soalan anda>
-Contoh:  camne nak buat file baru
-         camne cari file dalam folder ni
+Use:      camne <your question>
+Examples: camne nak buat file baru
+          camne how do I find a file in this folder
 
-Lain:    camne doctor   — semak apa yang dah dipasang
-         camne stop     — hentikan model yang duduk dalam memory
-         camne update   — check for a newer camne and install it
+Also:     camne doctor   — check what is already installed
+          camne stop     — shut down the model sitting in memory
+          camne update   — check for a newer camne and install it
 
-camne hanya tunjuk command — ia tak jalankan apa-apa.
+camne only shows you the command — it never runs anything.
 `)
 }

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# camne installer — muat turun binary dari GitHub Releases, sahkan checksum,
-# letak dalam PATH. Guna: curl -fsSL https://raw.githubusercontent.com/officialdad/camne/main/install.sh | sh
+# camne installer — downloads the binary from GitHub Releases, verifies its
+# checksum, puts it in PATH. Use: curl -fsSL https://raw.githubusercontent.com/officialdad/camne/main/install.sh | sh
 set -eu
 
 REPO="officialdad/camne"
@@ -8,15 +8,16 @@ REPO="officialdad/camne"
 case "$(uname -s)" in
 	Linux)  os=linux ;;
 	Darwin) os=darwin ;;
-	*) echo "Maaf, camne tak support OS ni: $(uname -s)." >&2
-	   echo "Untuk Windows, muat turun camne.exe dari https://github.com/$REPO/releases" >&2
+	*) echo "Sorry, camne does not support this OS: $(uname -s)." >&2
+	   echo "On Windows, download camne.exe from https://github.com/$REPO/releases instead." >&2
 	   exit 1 ;;
 esac
 
 case "$(uname -m)" in
 	x86_64|amd64)  arch=amd64 ;;
 	arm64|aarch64) arch=arm64 ;;
-	*) echo "Maaf, camne tak support CPU ni: $(uname -m)." >&2; exit 1 ;;
+	*) echo "Sorry, camne does not support this CPU: $(uname -m)." >&2
+	   echo "Ask for it at https://github.com/$REPO/issues" >&2; exit 1 ;;
 esac
 
 BIN="camne_${os}_${arch}"
@@ -38,14 +39,14 @@ fetch() {
 fetch "$TMP/release.json" "https://api.github.com/repos/$REPO/releases/latest" || true
 TAG=$(sed -n 's/^[[:space:]]*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' "$TMP/release.json" 2>/dev/null | head -1)
 if [ -z "$TAG" ]; then
-	echo "Tak jumpa release terbaru. Semak internet anda dan cuba lagi." >&2
+	echo "Could not find the latest release. Check your internet connection and try again." >&2
 	exit 1
 fi
 BASE="https://github.com/$REPO/releases/download/$TAG"
 
-echo "Muat turun camne $TAG ($os/$arch)..."
+echo "Downloading camne $TAG ($os/$arch)..."
 if ! fetch "$TMP/$BIN" "$BASE/$BIN" || ! fetch "$TMP/checksums.txt" "$BASE/checksums.txt"; then
-	echo "Muat turun gagal. Semak internet anda dan cuba lagi." >&2
+	echo "Download failed. Check your internet connection and try again." >&2
 	exit 1
 fi
 
@@ -57,7 +58,8 @@ else
 fi
 WANT=$(grep " $BIN\$" "$TMP/checksums.txt" | cut -d' ' -f1)
 if [ -z "$WANT" ] || [ "$SUM" != "$WANT" ]; then
-	echo "Checksum tak sepadan — fail mungkin rosak atau diubah. Tak install. Cuba lagi." >&2
+	echo "Checksum does not match — the file may be damaged or tampered with." >&2
+	echo "Nothing was installed. Try again." >&2
 	exit 1
 fi
 
@@ -71,10 +73,10 @@ fi
 chmod +x "$TMP/$BIN"
 mv "$TMP/$BIN" "$DIR/camne"
 
-echo "Siap! camne dah dipasang di $DIR/camne"
+echo "Done! camne is installed at $DIR/camne"
 case ":$PATH:" in
 	*":$DIR:"*) ;;
-	*) echo "Nota: tambah $DIR dalam PATH anda dulu, contoh:"
+	*) echo "Note: add $DIR to your PATH first, like this:"
 	   echo "  export PATH=\"\$PATH:$DIR\"" ;;
 esac
-echo "Cuba: camne nak buat file baru"
+echo "Try it: camne nak buat file baru"

--- a/internal/engine/endpoint_windows.go
+++ b/internal/engine/endpoint_windows.go
@@ -30,12 +30,12 @@ func tcpClient(port string) *Client {
 func newEndpoint(rd string) (*Client, []string, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, nil, errors.New("tak boleh buka port tempatan untuk llama-server — cuba lagi")
+		return nil, nil, errors.New("could not open a local port for llama-server — try again in a moment")
 	}
 	port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
 	l.Close()
 	if err := os.WriteFile(portPath(rd), []byte(port), 0o600); err != nil {
-		return nil, nil, fmt.Errorf("tak boleh simpan fail port: %w", err)
+		return nil, nil, fmt.Errorf("could not save the port file camne uses to find llama-server again — check you have free space in your home folder, then try again: %w", err)
 	}
 	return tcpClient(port), []string{"--host", "127.0.0.1", "--port", port}, nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -57,7 +57,7 @@ func runDir() (string, error) {
 	}
 	rd := filepath.Join(d, "run")
 	if err := os.MkdirAll(rd, 0o700); err != nil {
-		return "", fmt.Errorf("tak boleh buat folder run camne: %w", err)
+		return "", fmt.Errorf("could not create camne's working folder — check you have free space in your home folder, then try again: %w", err)
 	}
 	if runtime.GOOS != "windows" {
 		// MkdirAll leaves a pre-existing dir's mode alone: enforce it anyway,
@@ -117,7 +117,7 @@ func Connect(serverPath, modelPath string) (c *Client, cold bool, err error) {
 	}
 	cmd.SysProcAttr = detachAttr()
 	if err := cmd.Start(); err != nil {
-		return nil, false, fmt.Errorf("tak boleh start llama-server — jalankan `camne doctor` untuk semak: %w", err)
+		return nil, false, fmt.Errorf("could not start llama-server — run `camne doctor` to see what is missing: %w", err)
 	}
 	os.WriteFile(pidPath(rd), []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
 	cmd.Process.Release()
@@ -149,7 +149,7 @@ func (c *Client) WaitReady(timeout time.Duration) error {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return errors.New("model masih tak sedia — cuba `camne stop`, lepas tu tanya semula. Kalau masih gagal, `camne doctor` boleh tolong semak")
+			return errors.New("the model is still not ready — run `camne stop`, then ask again. If it keeps happening, `camne doctor` will show what is missing")
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
@@ -194,33 +194,33 @@ func (c *Client) Complete(query string) (string, error) {
 		RepeatLastN:   64,
 	})
 	if err != nil {
-		return "", fmt.Errorf("soalan tu tak boleh diproses: %w", err)
+		return "", fmt.Errorf("your question could not be prepared for the model — try rewording it, then ask again: %w", err)
 	}
 	// Generous cap: a server that idled to sleep reloads the model first.
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/completion", bytes.NewReader(body))
 	if err != nil {
-		return "", errors.New("tak dapat hubungi model — cuba `camne stop`, lepas tu tanya semula")
+		return "", errors.New("could not reach the model — run `camne stop`, then ask again")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return "", errors.New("tak dapat hubungi model — cuba `camne stop`, lepas tu tanya semula")
+		return "", errors.New("could not reach the model — run `camne stop`, then ask again")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("model bagi ralat (HTTP %d) — cuba `camne stop`, lepas tu tanya semula", resp.StatusCode)
+		return "", fmt.Errorf("the model gave an error (HTTP %d) — run `camne stop`, then ask again", resp.StatusCode)
 	}
 	var out struct {
 		Content string `json:"content"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return "", errors.New("jawapan model tak boleh dibaca — cuba tanya semula")
+		return "", errors.New("the model's answer could not be read — please ask again")
 	}
 	cmd := strings.TrimSpace(printable(out.Content))
 	if cmd == "" {
-		return "", errors.New("model tak bagi jawapan kali ni — cuba ubah ayat soalan tu sikit")
+		return "", errors.New("the model had no answer this time — try saying it a different way and ask again")
 	}
 	return cmd, nil
 }

--- a/internal/provision/download.go
+++ b/internal/provision/download.go
@@ -20,7 +20,7 @@ import (
 // interrupted copy leaves the .part in place so the next run resumes it.
 func Download(url, dest, wantSHA256 string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return fmt.Errorf("tak boleh buat folder cache: %w", err)
+		return fmt.Errorf("could not create camne's download folder — check you have free space in your home folder, then try again: %w", err)
 	}
 	part := dest + ".part"
 
@@ -31,14 +31,14 @@ func Download(url, dest, wantSHA256 string) error {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return fmt.Errorf("URL download tak sah: %w", err)
+		return fmt.Errorf("camne's download address is not valid — please report this at https://github.com/officialdad/camne/issues: %w", err)
 	}
 	if offset > 0 {
 		req.Header.Set("Range", "bytes="+strconv.FormatInt(offset, 10)+"-")
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("download gagal — semak sambungan internet, lepas tu cuba lagi: %w", err)
+		return fmt.Errorf("download failed — check your internet connection and try again: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -53,20 +53,20 @@ func Download(url, dest, wantSHA256 string) error {
 		// .part is already the full file (or junk). Verify decides which.
 		return verifyAndRename(part, dest, wantSHA256)
 	default:
-		return fmt.Errorf("download gagal (HTTP %d) — cuba lagi sekejap nanti", resp.StatusCode)
+		return fmt.Errorf("download failed (HTTP %d) — the server is having trouble, try again in a few minutes", resp.StatusCode)
 	}
 	if err != nil {
-		return fmt.Errorf("tak boleh tulis fail download: %w", err)
+		return fmt.Errorf("could not write the file being downloaded — check you have free space on your disk, then try again: %w", err)
 	}
 
 	_, copyErr := io.Copy(f, resp.Body)
 	closeErr := f.Close()
 	if copyErr != nil {
 		// Keep the .part: the next run resumes from here.
-		return fmt.Errorf("download terputus — jalankan semula, camne akan sambung dari mana ia berhenti: %w", copyErr)
+		return fmt.Errorf("the download was cut off — run camne again and it will carry on from where it stopped: %w", copyErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("tak boleh simpan fail download: %w", closeErr)
+		return fmt.Errorf("could not save the downloaded file — check you have free space on your disk, then try again: %w", closeErr)
 	}
 	return verifyAndRename(part, dest, wantSHA256)
 }
@@ -77,20 +77,20 @@ func Download(url, dest, wantSHA256 string) error {
 func verifyAndRename(part, dest, wantSHA256 string) error {
 	f, err := os.Open(part)
 	if err != nil {
-		return fmt.Errorf("tak boleh baca fail download: %w", err)
+		return fmt.Errorf("could not read the downloaded file back — run camne again to download a fresh copy: %w", err)
 	}
 	h := sha256.New()
 	_, err = io.Copy(h, f)
 	f.Close()
 	if err != nil {
-		return fmt.Errorf("tak boleh baca fail download: %w", err)
+		return fmt.Errorf("could not read the downloaded file back — run camne again to download a fresh copy: %w", err)
 	}
 	if got := hex.EncodeToString(h.Sum(nil)); got != wantSHA256 {
 		os.Remove(part)
-		return fmt.Errorf("download rosak (checksum tak sepadan) — fail dah dibuang, cuba download semula")
+		return fmt.Errorf("the download is damaged (checksum does not match) — the bad file has been deleted, run camne again to download a fresh copy")
 	}
 	if err := os.Rename(part, dest); err != nil {
-		return fmt.Errorf("tak boleh simpan fail yang dah siap: %w", err)
+		return fmt.Errorf("the download finished but could not be moved into place — check you have free space on your disk, then try again: %w", err)
 	}
 	return nil
 }

--- a/internal/provision/extract.go
+++ b/internal/provision/extract.go
@@ -22,7 +22,7 @@ import (
 func ExtractZip(archive, destDir string, keep func(name string) bool) error {
 	r, err := zip.OpenReader(archive)
 	if err != nil {
-		return fmt.Errorf("arkib rosak, tak boleh dibuka — padam dan download semula: %w", err)
+		return fmt.Errorf("the downloaded file is damaged and will not open — run camne again to download a fresh copy: %w", err)
 	}
 	defer r.Close()
 	for _, f := range r.File {
@@ -35,7 +35,7 @@ func ExtractZip(archive, destDir string, keep func(name string) bool) error {
 		}
 		rc, err := f.Open()
 		if err != nil {
-			return fmt.Errorf("arkib rosak — padam dan download semula: %w", err)
+			return fmt.Errorf("the downloaded file is damaged — run camne again to download a fresh copy: %w", err)
 		}
 		err = writeFile(dst, rc, f.Mode())
 		rc.Close()
@@ -52,12 +52,12 @@ func ExtractZip(archive, destDir string, keep func(name string) bool) error {
 func ExtractTarGz(archive, destDir string, keep func(name string) bool) error {
 	f, err := os.Open(archive)
 	if err != nil {
-		return fmt.Errorf("arkib rosak, tak boleh dibuka — padam dan download semula: %w", err)
+		return fmt.Errorf("the downloaded file is damaged and will not open — run camne again to download a fresh copy: %w", err)
 	}
 	defer f.Close()
 	gz, err := gzip.NewReader(f)
 	if err != nil {
-		return fmt.Errorf("arkib rosak, tak boleh dibuka — padam dan download semula: %w", err)
+		return fmt.Errorf("the downloaded file is damaged and will not open — run camne again to download a fresh copy: %w", err)
 	}
 	defer gz.Close()
 	tr := tar.NewReader(gz)
@@ -67,7 +67,7 @@ func ExtractTarGz(archive, destDir string, keep func(name string) bool) error {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("arkib rosak — padam dan download semula: %w", err)
+			return fmt.Errorf("the downloaded file is damaged — run camne again to download a fresh copy: %w", err)
 		}
 		if !keep(hdr.Name) {
 			continue
@@ -96,11 +96,11 @@ func ExtractTarGz(archive, destDir string, keep func(name string) bool) error {
 				return err
 			}
 			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-				return fmt.Errorf("tak boleh unpack: %w", err)
+				return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", err)
 			}
 			os.Remove(dst) // re-extraction over an old link
 			if err := os.Symlink(hdr.Linkname, dst); err != nil {
-				return fmt.Errorf("tak boleh unpack: %w", err)
+				return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", err)
 			}
 		}
 		// Directories are created as needed by writeFile; other types
@@ -114,26 +114,26 @@ func ExtractTarGz(archive, destDir string, keep func(name string) bool) error {
 func safeJoin(destDir, name string) (string, error) {
 	local := filepath.FromSlash(name)
 	if strings.Contains(name, `\`) || !filepath.IsLocal(local) {
-		return "", fmt.Errorf("arkib mengandungi nama fail bahaya (%q) — padam dan download semula", name)
+		return "", fmt.Errorf("the downloaded file contains an unsafe file name (%q), so nothing was unpacked — run camne again to download a fresh copy", name)
 	}
 	return filepath.Join(destDir, local), nil
 }
 
 func writeFile(dst string, src io.Reader, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("tak boleh unpack: %w", err)
+		return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", err)
 	}
 	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
-		return fmt.Errorf("tak boleh unpack: %w", err)
+		return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", err)
 	}
 	_, copyErr := io.Copy(f, src)
 	closeErr := f.Close()
 	if copyErr != nil {
-		return fmt.Errorf("tak boleh unpack: %w", copyErr)
+		return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", copyErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("tak boleh unpack: %w", closeErr)
+		return fmt.Errorf("could not unpack the download — check you have free space on your disk, then try again: %w", closeErr)
 	}
 	return nil
 }

--- a/internal/provision/glibc.go
+++ b/internal/provision/glibc.go
@@ -16,8 +16,8 @@ const glibcMinMajor, glibcMinMinor = 2, 34
 // get a diagnosis, not a fix. Upgrade path: pin a static/compat llama.cpp
 // build (as whatisit's fetch.py does) and select it here.
 
-// libcNote returns a colloquial-Malay note when this machine's libc cannot
-// run the prebuilt llama.cpp, or "" when it can (or this is not Linux).
+// libcNote returns a plain-English note when this machine's libc cannot run
+// the prebuilt llama.cpp, or "" when it can (or this is not Linux).
 func libcNote() string {
 	if runtime.GOOS != "linux" {
 		return ""
@@ -26,19 +26,19 @@ func libcNote() string {
 	if err != nil && len(out) == 0 {
 		// No ldd at all — usually musl or a container image stripped bare.
 		if m, _ := filepath.Glob("/lib/ld-musl-*"); len(m) > 0 {
-			return "sistem ni guna musl (macam Alpine) — llama-server prebuilt tak akan jalan kat sini"
+			return "this system uses musl (Alpine and friends), so the ready-made llama-server will not run here — camne needs a system built on glibc 2.34 or newer, such as Ubuntu or Debian"
 		}
-		return "tak dapat kesan versi glibc — kalau llama-server tak jalan nanti, ini mungkin sebabnya"
+		return "could not work out this system's glibc version — if llama-server fails to start later, this is probably why"
 	}
 	musl, major, minor, ok := parseLddVersion(string(out))
 	switch {
 	case musl:
-		return "sistem ni guna musl (macam Alpine) — llama-server prebuilt tak akan jalan kat sini"
+		return "this system uses musl (Alpine and friends), so the ready-made llama-server will not run here — camne needs a system built on glibc 2.34 or newer, such as Ubuntu or Debian"
 	case !ok:
-		return "tak dapat kesan versi glibc — kalau llama-server tak jalan nanti, ini mungkin sebabnya"
+		return "could not work out this system's glibc version — if llama-server fails to start later, this is probably why"
 	case major < glibcMinMajor || (major == glibcMinMajor && minor < glibcMinMinor):
 		return "glibc " + strconv.Itoa(major) + "." + strconv.Itoa(minor) +
-			" terlalu lama (perlu 2.34 ke atas) — llama-server prebuilt tak akan jalan kat sini"
+			" is too old, so the ready-made llama-server will not run here — camne needs glibc 2.34 or newer, which comes with a newer version of your system"
 	}
 	return ""
 }

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -56,7 +56,7 @@ var llamaAssets = map[string]Asset{
 func LlamaAsset(goos, goarch string) (Asset, error) {
 	a, ok := llamaAssets[goos+"/"+goarch]
 	if !ok {
-		return Asset{}, fmt.Errorf("camne belum support %s/%s lagi — buka issue kat GitHub kalau anda perlukan platform ni", goos, goarch)
+		return Asset{}, fmt.Errorf("camne does not support %s/%s yet — open an issue at https://github.com/officialdad/camne/issues if you need this platform", goos, goarch)
 	}
 	return a, nil
 }
@@ -69,7 +69,7 @@ func LlamaAsset(goos, goarch string) (Asset, error) {
 func Dir() (string, error) {
 	c, err := os.UserCacheDir()
 	if err != nil {
-		return "", fmt.Errorf("tak jumpa folder cache sistem: %w", err)
+		return "", fmt.Errorf("could not find your system's cache folder, so camne has nowhere to keep its files — check that HOME is set, then try again: %w", err)
 	}
 	return filepath.Join(c, "camne"), nil
 }


### PR DESCRIPTION
Closes #25.

**Merge this last.** It is stacked on `feat/self-update` (#27) and `feat/warning-shape` (#28) because it rewrites the same strings they touch. Until both land, the diff below shows their commits too.

Everything camne prints is now English. Input is unchanged — `camne nak buat file baru` still works, camne just answers in English.

```
camne — ask in plain Malay or English, get a shell command.

Use:      camne <your question>
Examples: camne nak buat file baru
          camne how do I find a file in this folder

Also:     camne doctor   — check what is already installed
          camne stop     — shut down the model sitting in memory
          camne update   — check for a newer camne and install it

camne only shows you the command — it never runs anything.
```

The Malay example on the first screen is deliberate: it is the fastest way to show that Malay input still works.

## Why this needs doc changes to be correct

`CLAUDE.md`'s *User-facing text* section said the opposite of this PR. Without editing it, the next contributor "fixes" these strings back to Malay and is right to. It now says English output, multilingual input, and names the trap directly: *do not "fix" a printed string back to Malay*.

Constraint 5 also said "`BAHAYA` never auto-runs" in both `CLAUDE.md` and `CONTRIBUTING.md`. That string no longer exists, so the rule was pointing at nothing — it now reads "camne prints the command and stops there; a command the safety checker flags is still only printed."

## Six messages gained a next step

CLAUDE.md requires that errors say what to do next, and a literal translation would have preserved six dead ends. These were rewritten rather than translated:

- cache-folder creation, working-folder creation, port-file write, and download write/save → "check you have free space … then try again"
- invalid download URL — a pinned-constant bug, not a user error → points at the issue tracker
- musl and old-glibc notes → now name the fix (a glibc 2.34+ system, or a newer version of the current one) instead of only stating that the prebuilt binary will not run
- `install.sh`'s unsupported-CPU branch → gained an issue-tracker line, matching the OS branch that already pointed at releases

## Malay deliberately kept

All of it is input or a quotation of input, never output: the `usage()` and `install.sh` demo queries (constraint 1), the `engine` and `color` test fixtures, and the quoted queries in `README.md`, `RESULTS.md`, `dataset/README.md` and constraint 1 of both doc files.

## Verification

```
$ gofmt -l .            (no output)
$ go build ./... && go vet ./...
$ go test ./...
ok  	github.com/officialdad/camne/cmd/camne	0.010s
ok  	github.com/officialdad/camne/internal/engine	0.607s
ok  	github.com/officialdad/camne/internal/provision	0.011s
ok  	github.com/officialdad/camne/internal/safety	0.453s
$ sh -n install.sh      ok
```

Cross-compiles clean for windows/amd64 and darwin/arm64 — `endpoint_windows.go` changed and the host toolchain would not otherwise compile it. A grep for Malay across every non-test Go string literal and every `install.sh` echo comes back empty.

No test asserted on a Malay output string, so none needed changing.

## Known gap

`demo/demo.gif` still shows the old Malay output, and `README.md:21`'s alt text describes it accurately. Both need updating together with a re-record — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
