### PR TITLE
feat: show speed and time left while camne downloads

### DIFF
--- a/cmd/camne/install.go
+++ b/cmd/camne/install.go
@@ -101,24 +101,45 @@ func installServer(asset provision.Asset, serverPath string) error {
 	return nil
 }
 
-// withProgress runs dl while a ticker prints how many MB of the .part file
-// are on disk so a 1 GB download is never a silent stall.
+// withProgress runs dl while a ticker prints how much of the .part file is on
+// disk, how fast it is arriving, and how long is left, so a 1 GB download is
+// never a silent stall. The speed is what makes a stalled download look
+// different from a slow one; the byte counter alone cannot show that, and a
+// download that looks hung gets killed and restarted.
+//
+// Nothing is drawn when stderr is not a terminal: the line rewrites itself with
+// \r, which is noise in a redirected log.
+//
 // ponytail: polls the .part size instead of instrumenting Download — coarse
 // (500 ms) but shows resumed downloads correctly; a progress callback on
 // provision.Download is the upgrade path.
 func withProgress(partPath string, total int64, dl func() error) error {
+	if !isTTY(os.Stderr) {
+		return dl()
+	}
 	done := make(chan struct{})
 	go func() {
 		t := time.NewTicker(500 * time.Millisecond)
 		defer t.Stop()
+		prev, last := int64(-1), time.Now()
+		rate := -1.0 // negative until there are two samples to compare
 		for {
 			select {
 			case <-done:
 				return
-			case <-t.C:
-				if fi, err := os.Stat(partPath); err == nil {
-					fmt.Fprintf(os.Stderr, "\r  %d/%d MB", fi.Size()/1_000_000, total/1_000_000)
+			case now := <-t.C:
+				fi, err := os.Stat(partPath)
+				if err != nil {
+					continue // not created yet, or already renamed into place
 				}
+				got := fi.Size()
+				if secs := now.Sub(last).Seconds(); prev >= 0 && secs > 0 {
+					rate = smoothRate(rate, float64(got-prev)/secs)
+				}
+				prev, last = got, now
+				// Left-padded: the line shrinks when the estimate drops off the
+				// end, and \r alone would leave the old tail on screen.
+				fmt.Fprintf(os.Stderr, "\r%-70s", progressLine(got, total, rate))
 			}
 		}
 	}()
@@ -126,4 +147,69 @@ func withProgress(partPath string, total int64, dl func() error) error {
 	close(done)
 	fmt.Fprintln(os.Stderr)
 	return err
+}
+
+// barWidth is in characters, chosen to leave the whole progress line inside 70
+// columns — the narrowest terminal worth designing for.
+const barWidth = 24
+
+// smoothRate folds one speed sample into an exponential moving average.
+// A negative prev means nothing has been measured yet, so the first sample is
+// taken whole rather than averaged against a number that does not exist.
+//
+// Smoothing is what keeps the line honest in both directions: raw 500 ms
+// samples swing wildly with TCP windowing, so every pause would read as a stall
+// and every burst as a miracle. It also decays rather than snapping, so a real
+// stall visibly falls towards zero over a few seconds instead of flickering.
+func smoothRate(prev, sample float64) float64 {
+	if prev < 0 {
+		return sample
+	}
+	return 0.7*prev + 0.3*sample
+}
+
+// progressLine renders one progress line: bar, megabytes, speed, estimate.
+// rate is bytes per second, or negative when nothing has been measured yet.
+//
+// A measured rate of zero prints as "0.0 MB/s" with no estimate rather than
+// being hidden. That is the whole point of showing a speed: a download that has
+// stopped must not look like one that is merely slow.
+func progressLine(got, total int64, rate float64) string {
+	if total <= 0 {
+		return fmt.Sprintf("  %d MB", got/1_000_000)
+	}
+	if got > total {
+		got = total // a resumed .part can briefly overshoot a stale total
+	}
+	filled := int(got * barWidth / total)
+	line := fmt.Sprintf("  [%s%s] %3d%%  %d/%d MB",
+		strings.Repeat("#", filled), strings.Repeat(".", barWidth-filled),
+		got*100/total, got/1_000_000, total/1_000_000)
+	if rate < 0 {
+		return line
+	}
+	line += fmt.Sprintf("  %.1f MB/s", rate/1_000_000)
+	// No estimate on the last frame: "0s left" under a full bar is noise.
+	if rate > 0 && got < total {
+		line += "  " + eta(float64(total-got)/rate)
+	}
+	return line
+}
+
+// eta phrases the seconds left for someone watching a download rather than
+// timing one. Anything past an hour is said in words: at that point the number
+// is a guess about a stalled connection, and printing "417m 12s left" reads as
+// a broken program.
+func eta(secs float64) string {
+	s := int(secs + 0.5)
+	switch {
+	case s >= 3600:
+		return "over an hour left"
+	case s >= 60:
+		return fmt.Sprintf("%dm %ds left", s/60, s%60)
+	case s < 1:
+		// The last megabytes, where "0s left" reads as a stuck clock.
+		return "almost done"
+	}
+	return fmt.Sprintf("%ds left", s)
 }

--- a/cmd/camne/install_test.go
+++ b/cmd/camne/install_test.go
@@ -1,0 +1,84 @@
+package main
+
+import "testing"
+
+func TestProgressLine(t *testing.T) {
+	const mb = 1_000_000
+	for _, tc := range []struct {
+		name       string
+		got, total int64
+		rate       float64
+		want       string
+	}{
+		{"nothing measured yet omits speed and estimate", 0, 986 * mb, -1,
+			"  [........................]   0%  0/986 MB"},
+		{"halfway", 493 * mb, 986 * mb, 16 * mb,
+			"  [############............]  50%  493/986 MB  16.0 MB/s  31s left"},
+		// The reason the speed is on the line at all: stopped must not read
+		// the same as slow.
+		{"stalled shows zero speed and no estimate", 400 * mb, 986 * mb, 0,
+			"  [#########...............]  40%  400/986 MB  0.0 MB/s"},
+		{"minutes left", 100 * mb, 986 * mb, 3 * mb,
+			"  [##......................]  10%  100/986 MB  3.0 MB/s  4m 55s left"},
+		{"a crawl is phrased, not counted", 10 * mb, 986 * mb, 1000,
+			"  [........................]   1%  10/986 MB  0.0 MB/s  over an hour left"},
+		// The last frame drops the estimate: "0s left" under a full bar is noise.
+		{"complete", 986 * mb, 986 * mb, 16 * mb,
+			"  [########################] 100%  986/986 MB  16.0 MB/s"},
+		// A resumed .part measured against a stale total must not print a bar
+		// longer than the bar or a percentage over 100.
+		{"overshoot is clamped", 999 * mb, 986 * mb, -1,
+			"  [########################] 100%  986/986 MB"},
+		{"unknown total falls back to a counter", 42 * mb, 0, -1, "  42 MB"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := progressLine(tc.got, tc.total, tc.rate); got != tc.want {
+				t.Errorf("progressLine(%d, %d, %v)\n got %q\nwant %q",
+					tc.got, tc.total, tc.rate, got, tc.want)
+			}
+		})
+	}
+}
+
+// A stall has to become visible on the line within a few seconds, and a burst
+// must not be believed on the strength of one sample. Both are the same knob.
+func TestSmoothRateDecaysOnAStall(t *testing.T) {
+	const mb = 1_000_000
+	if got := smoothRate(-1, 20*mb); got != 20*mb {
+		t.Fatalf("first sample should be taken whole, got %v", got)
+	}
+	// Steady at 20 MB/s, then the connection dies: four ticks is two seconds.
+	rate := 20.0 * mb
+	for i := 0; i < 4; i++ {
+		rate = smoothRate(rate, 0)
+	}
+	if rate > 5*mb {
+		t.Errorf("after 2s of no bytes the rate still reads %.1f MB/s; a stall must be visible", rate/mb)
+	}
+	// One fast sample must not triple the displayed speed.
+	if got := smoothRate(10*mb, 60*mb); got > 25*mb {
+		t.Errorf("single burst moved the rate to %.1f MB/s, too twitchy", got/mb)
+	}
+}
+
+func TestETA(t *testing.T) {
+	for _, tc := range []struct {
+		secs float64
+		want string
+	}{
+		{0, "almost done"},
+		{0.4, "almost done"},
+		{1.4, "1s left"},
+		{59, "59s left"},
+		{59.6, "1m 0s left"}, // rounds up across the boundary, not down to 59s
+		{60, "1m 0s left"},
+		{125, "2m 5s left"},
+		{3599, "59m 59s left"},
+		{3600, "over an hour left"},
+		{86400, "over an hour left"},
+	} {
+		if got := eta(tc.secs); got != tc.want {
+			t.Errorf("eta(%v) = %q, want %q", tc.secs, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The download line was `414/986 MB`, redrawn every 500 ms by a ticker polling the `.part` file — whether or not any bytes had arrived. At 3 MB/s a 1 GB model takes five and a half minutes, and for all of it a working download looked exactly like a dead one. A run that looks hung gets killed and restarted.

## Change

```
  [####....................]  18%  177/986 MB  5.6 MB/s  2m 25s left
```

Real capture from a first run under a pty.

The speed is the part that matters. It's an exponential moving average of the bytes landing between ticks, so:

- a stall **decays visibly toward zero** over a few seconds instead of flickering
- one fast sample can't triple the displayed rate
- a measured zero prints as `0.0 MB/s` rather than being hidden — stopped must not read the same as slow

Rendered frames across a simulated five-second stall, showing the counter freeze while the rate falls:

```
  [##......................]  10%   99/986 MB  18.0 MB/s  49s left
  [##......................]  10%  108/986 MB  12.6 MB/s  1m 10s left
  [##......................]  10%  108/986 MB   8.8 MB/s  1m 40s left
  [##......................]  10%  108/986 MB   6.2 MB/s  2m 22s left
  ...
  [###.....................]  13%  135/986 MB  12.0 MB/s  1m 11s left   ← recovers
```

Nothing is drawn when stderr is not a terminal — the line rewrites itself with `\r`, which is noise in a redirected log. Verified: zero `\r` bytes in redirected output, and the announcement lines still print so a log still says what's being fetched.

Edge cases the tests pin: the last frame drops the estimate (`0s left` under a full bar reads as a stuck clock, now `almost done` then nothing), a resumed `.part` measured against a stale total can't render a bar past 100%, and a crawling connection says `over an hour left` instead of `417m 12s left`.

## Why presentation only

This started as an investigation into camne downloading slower than `whatisit`. Measured on one box, alternating full 986 MB downloads: camne's `provision.Download` finished in 48.5 s and 58.2 s against whatisit's 66.7 s and 141.0 s on an identical URL. camne's downloader is the faster of the two — it just couldn't show it was working.

There is a real ~4× gap between the two **model repos** on Hugging Face, unrelated to this code and not fixed here.

## Verification

- `go test ./...` green, `go vet` clean, `gofmt` clean
- Real first-run download under a pty, output above
- Non-TTY path: `grep -c $'\r'` on redirected output returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)