### PR TITLE
feat: split large downloads across eight connections

### DIFF
--- a/cmd/camne/install.go
+++ b/cmd/camne/install.go
@@ -47,8 +47,8 @@ func ensureProvisioned(st provision.Status) bool {
 	}
 	if !st.ModelOK {
 		fmt.Fprintln(os.Stderr, "Downloading the model...")
-		if err := withProgress(st.ModelPath+".part", provision.ModelSize, func() error {
-			return provision.Download(provision.ModelURL, st.ModelPath, provision.ModelSHA256)
+		if err := withProgress(st.ModelPath, provision.ModelSize, func() error {
+			return provision.Download(provision.ModelURL, st.ModelPath, provision.ModelSize, provision.ModelSHA256)
 		}); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return false
@@ -68,8 +68,8 @@ func installServer(asset provision.Asset, serverPath string) error {
 	}
 	archive := filepath.Join(cacheDir, "downloads", asset.Name)
 	fmt.Fprintln(os.Stderr, "Downloading llama-server...")
-	if err := withProgress(archive+".part", asset.Size, func() error {
-		return provision.Download(asset.URL(), archive, asset.SHA256)
+	if err := withProgress(archive, asset.Size, func() error {
+		return provision.Download(asset.URL(), archive, asset.Size, asset.SHA256)
 	}); err != nil {
 		return err
 	}
@@ -101,19 +101,20 @@ func installServer(asset provision.Asset, serverPath string) error {
 	return nil
 }
 
-// withProgress runs dl while a ticker prints how much of the .part file is on
-// disk, how fast it is arriving, and how long is left, so a 1 GB download is
-// never a silent stall. The speed is what makes a stalled download look
-// different from a slow one; the byte counter alone cannot show that, and a
-// download that looks hung gets killed and restarted.
+// withProgress runs dl while a ticker prints how much of dest is on disk, how
+// fast it is arriving, and how long is left, so a 1 GB download is never a
+// silent stall. The speed is what makes a stalled download look different from
+// a slow one; the byte counter alone cannot show that, and a download that
+// looks hung gets killed and restarted.
 //
 // Nothing is drawn when stderr is not a terminal: the line rewrites itself with
 // \r, which is noise in a redirected log.
 //
-// ponytail: polls the .part size instead of instrumenting Download — coarse
-// (500 ms) but shows resumed downloads correctly; a progress callback on
+// ponytail: polls provision.PartBytes instead of instrumenting Download —
+// coarse (500 ms) but counts a single stream, eight parallel segments, and the
+// join between them without knowing which is running; a progress callback on
 // provision.Download is the upgrade path.
-func withProgress(partPath string, total int64, dl func() error) error {
+func withProgress(dest string, total int64, dl func() error) error {
 	if !isTTY(os.Stderr) {
 		return dl()
 	}
@@ -128,11 +129,12 @@ func withProgress(partPath string, total int64, dl func() error) error {
 			case <-done:
 				return
 			case now := <-t.C:
-				fi, err := os.Stat(partPath)
-				if err != nil {
-					continue // not created yet, or already renamed into place
+				got := provision.PartBytes(dest)
+				if got == 0 {
+					// Not started yet, or already renamed into place — either
+					// way, do not redraw the bar back to zero.
+					continue
 				}
-				got := fi.Size()
 				if secs := now.Sub(last).Seconds(); prev >= 0 && secs > 0 {
 					rate = smoothRate(rate, float64(got-prev)/secs)
 				}
@@ -185,7 +187,10 @@ func progressLine(got, total int64, rate float64) string {
 	line := fmt.Sprintf("  [%s%s] %3d%%  %d/%d MB",
 		strings.Repeat("#", filled), strings.Repeat(".", barWidth-filled),
 		got*100/total, got/1_000_000, total/1_000_000)
-	if rate < 0 {
+	// No speed once every byte is down: what follows is joining the segments
+	// and hashing the result, and a rate falling to 0.0 MB/s there would read
+	// as the stall this line exists to make visible.
+	if rate < 0 || got >= total {
 		return line
 	}
 	line += fmt.Sprintf("  %.1f MB/s", rate/1_000_000)

--- a/cmd/camne/install_test.go
+++ b/cmd/camne/install_test.go
@@ -22,9 +22,11 @@ func TestProgressLine(t *testing.T) {
 			"  [##......................]  10%  100/986 MB  3.0 MB/s  4m 55s left"},
 		{"a crawl is phrased, not counted", 10 * mb, 986 * mb, 1000,
 			"  [........................]   1%  10/986 MB  0.0 MB/s  over an hour left"},
-		// The last frame drops the estimate: "0s left" under a full bar is noise.
+		// The last frames drop both speed and estimate: after the final byte
+		// camne is joining segments and hashing, and a rate decaying to zero
+		// there would look like the stall this line exists to expose.
 		{"complete", 986 * mb, 986 * mb, 16 * mb,
-			"  [########################] 100%  986/986 MB  16.0 MB/s"},
+			"  [########################] 100%  986/986 MB"},
 		// A resumed .part measured against a stale total must not print a bar
 		// longer than the bar or a percentage over 100.
 		{"overshoot is clamped", 999 * mb, 986 * mb, -1,

--- a/cmd/camne/update.go
+++ b/cmd/camne/update.go
@@ -218,7 +218,9 @@ func selfUpdate(tag string) error {
 	// rename below is atomic, and a directory camne cannot write to fails here
 	// rather than after a pointless download.
 	staged := self + ".new"
-	if err := provision.Download(releaseBase+tag+"/"+asset, staged, want); err != nil {
+	// Size 0: checksums.txt carries no length, and a camne binary is small
+	// enough that splitting it across connections would cost more than it saves.
+	if err := provision.Download(releaseBase+tag+"/"+asset, staged, 0, want); err != nil {
 		return fmt.Errorf("%w\ncamne was not changed. You can also reinstall with install.sh", err)
 	}
 	if err := os.Chmod(staged, 0o755); err != nil {

--- a/internal/provision/download.go
+++ b/internal/provision/download.go
@@ -3,27 +3,224 @@ package provision
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 )
 
-// Download fetches url into dest. It streams into dest+".part", resumes an
-// interrupted .part with a Range request, verifies the sha256 of the complete
-// file BEFORE the atomic rename — never after — and deletes the partial file
-// on a failed verification, so nothing corrupted can ever sit at dest.
+// parallelStreams is how many ranged requests share a download.
 //
-// On a student's connection a 1 GB download WILL be interrupted; an
-// interrupted copy leaves the .part in place so the next run resumes it.
-func Download(url, dest, wantSHA256 string) error {
+// Measured against the pinned model, three alternating rounds on one link:
+// one stream moved 986 MB in 58.8s / 67.8s / 58.8s, eight streams in
+// 14.4s / 47.1s / 15.8s — a median of 15.8s against 58.8s, and every parallel
+// run beat every single-stream run. The limit is per-connection, not
+// bandwidth: the same file reaches 62-68 MB/s split eight ways and 15-17 MB/s
+// whole. Hugging Face reconstructs Xet-backed files server-side for clients
+// that speak plain HTTP, which is every client camne has.
+const parallelStreams = 8
+
+// parallelMin is the size below which one stream is simply better: eight
+// connections cost eight TLS handshakes, and the llama-server archive is
+// 17 MB. A var, not a const, so the tests can exercise the split path without
+// moving 64 MB around.
+var parallelMin int64 = 64 << 20
+
+// errNoRange means the server sent the whole file instead of the range asked
+// for, so the download cannot be split. Not a user-facing error: Download
+// catches it and falls back to a single stream.
+var errNoRange = errors.New("server ignored the Range request")
+
+// Download fetches url into dest, whose length must be size bytes. Pass 0 for
+// size when the length is not known ahead of time; the download then takes the
+// single-stream path, which needs no length.
+//
+// Large downloads are split into parallelStreams ranged requests, each with
+// its own .partN file, joined once every part is whole. Small ones, and
+// servers that ignore Range, take a single stream. Either way it verifies the
+// sha256 of the complete file BEFORE the atomic rename — never after — and
+// deletes the partial file on a failed verification, so nothing corrupted can
+// ever sit at dest.
+//
+// On a student's connection a 1 GB download WILL be interrupted; every partial
+// file stays on disk so the next run resumes it rather than starting again.
+func Download(url, dest string, size int64, wantSHA256 string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return fmt.Errorf("could not create camne's download folder — check you have free space in your home folder, then try again: %w", err)
 	}
 	part := dest + ".part"
 
+	if size >= parallelMin {
+		err := downloadSegments(url, dest, size)
+		if err == nil {
+			if err := joinSegments(dest, parallelStreams); err != nil {
+				return err
+			}
+			return verifyAndRename(part, dest, wantSHA256)
+		}
+		if !errors.Is(err, errNoRange) {
+			return err
+		}
+		// One stream instead, from scratch: the segments hold ranges this
+		// server will not serve, so they are worth nothing now.
+		removeSegments(dest, parallelStreams)
+	}
+
+	if err := downloadWhole(url, part); err != nil {
+		return err
+	}
+	return verifyAndRename(part, dest, wantSHA256)
+}
+
+// segPath names the file holding segment i. The suffix carries a digit so a
+// glob for the segments never picks up the joined .part file.
+func segPath(dest string, i int) string { return dest + ".part" + strconv.Itoa(i) }
+
+// PartBytes reports how many bytes of dest are on disk across every partial
+// file, whichever path the download took. The progress display polls this: it
+// is the one number that means the same thing for a single stream, for eight
+// segments, and while they are being joined.
+func PartBytes(dest string) int64 {
+	names, _ := filepath.Glob(dest + ".part*")
+	var n int64
+	for _, name := range names {
+		if fi, err := os.Stat(name); err == nil {
+			n += fi.Size()
+		}
+	}
+	return n
+}
+
+func removeSegments(dest string, n int) {
+	for i := 0; i < n; i++ {
+		os.Remove(segPath(dest, i))
+	}
+}
+
+// downloadSegments fetches every segment concurrently and returns once they
+// are all whole. A segment that fails leaves its bytes on disk for the next
+// run; only the error comes back.
+func downloadSegments(url, dest string, size int64) error {
+	span := size / parallelStreams
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for i := 0; i < parallelStreams; i++ {
+		lo := int64(i) * span
+		hi := lo + span - 1
+		if i == parallelStreams-1 {
+			hi = size - 1 // the last segment carries the remainder
+		}
+		wg.Add(1)
+		go func(i int, lo, hi int64) {
+			defer wg.Done()
+			if err := downloadSegment(url, segPath(dest, i), lo, hi); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(i, lo, hi)
+	}
+	wg.Wait()
+	return firstErr
+}
+
+// downloadSegment fills path with url's bytes [lo,hi], resuming whatever is
+// already there. A segment longer than its span is junk from an interrupted
+// run under different settings, so it is thrown away rather than trusted.
+func downloadSegment(url, path string, lo, hi int64) error {
+	want := hi - lo + 1
+	var have int64
+	if fi, err := os.Stat(path); err == nil {
+		have = fi.Size()
+		if have > want {
+			os.Remove(path)
+			have = 0
+		}
+	}
+	if have == want {
+		return nil // already whole from an earlier run
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("camne's download address is not valid — please report this at https://github.com/officialdad/camne/issues: %w", err)
+	}
+	req.Header.Set("Range", "bytes="+strconv.FormatInt(lo+have, 10)+"-"+strconv.FormatInt(hi, 10))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download failed — check your internet connection and try again: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+	case http.StatusOK:
+		return errNoRange
+	case http.StatusRequestedRangeNotSatisfiable:
+		return nil // nothing left of this segment to ask for
+	default:
+		return fmt.Errorf("download failed (HTTP %d) — the server is having trouble, try again in a few minutes", resp.StatusCode)
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("could not write the file being downloaded — check you have free space on your disk, then try again: %w", err)
+	}
+	// Bounded by the span, never by what the server chooses to send: a server
+	// answering a range request with more than the range must not be able to
+	// push one segment over another's bytes.
+	_, copyErr := io.Copy(f, io.LimitReader(resp.Body, want-have))
+	closeErr := f.Close()
+	if copyErr != nil {
+		return fmt.Errorf("the download was cut off — run camne again and it will carry on from where it stopped: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("could not save the downloaded file — check you have free space on your disk, then try again: %w", closeErr)
+	}
+	return nil
+}
+
+// joinSegments concatenates the segments into dest+".part" in order, deleting
+// each one as it lands so the peak disk cost is the file plus one segment,
+// not the file twice.
+func joinSegments(dest string, n int) error {
+	part := dest + ".part"
+	f, err := os.Create(part)
+	if err != nil {
+		return fmt.Errorf("could not write the file being downloaded — check you have free space on your disk, then try again: %w", err)
+	}
+	for i := 0; i < n; i++ {
+		s, err := os.Open(segPath(dest, i))
+		if err != nil {
+			f.Close()
+			return fmt.Errorf("could not read the downloaded file back — run camne again to download a fresh copy: %w", err)
+		}
+		_, copyErr := io.Copy(f, s)
+		s.Close()
+		if copyErr != nil {
+			f.Close()
+			return fmt.Errorf("could not save the downloaded file — check you have free space on your disk, then try again: %w", copyErr)
+		}
+		os.Remove(segPath(dest, i))
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("could not save the downloaded file — check you have free space on your disk, then try again: %w", err)
+	}
+	return nil
+}
+
+// downloadWhole streams the entire file into part on one connection, resuming
+// an interrupted part with a Range request. This is the path for small files
+// and for servers that will not serve ranges.
+func downloadWhole(url, part string) error {
 	var offset int64
 	if fi, err := os.Stat(part); err == nil {
 		offset = fi.Size()
@@ -51,7 +248,7 @@ func Download(url, dest, wantSHA256 string) error {
 		f, err = os.Create(part)
 	case http.StatusRequestedRangeNotSatisfiable:
 		// .part is already the full file (or junk). Verify decides which.
-		return verifyAndRename(part, dest, wantSHA256)
+		return nil
 	default:
 		return fmt.Errorf("download failed (HTTP %d) — the server is having trouble, try again in a few minutes", resp.StatusCode)
 	}
@@ -68,7 +265,7 @@ func Download(url, dest, wantSHA256 string) error {
 	if closeErr != nil {
 		return fmt.Errorf("could not save the downloaded file — check you have free space on your disk, then try again: %w", closeErr)
 	}
-	return verifyAndRename(part, dest, wantSHA256)
+	return nil
 }
 
 // verifyAndRename hashes the complete .part and only then renames it to dest.

--- a/internal/provision/download_test.go
+++ b/internal/provision/download_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -86,7 +88,7 @@ func TestDownload(t *testing.T) {
 				}
 			}
 
-			err := Download(srv.URL, dest, tt.want)
+			err := Download(srv.URL, dest, int64(len(payload)), tt.want)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -120,10 +122,188 @@ func TestDownloadHTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
 	dest := filepath.Join(t.TempDir(), "file.bin")
-	if err := Download(srv.URL, dest, sum(nil)); err == nil {
+	if err := Download(srv.URL, dest, 0, sum(nil)); err == nil {
 		t.Fatal("expected error on HTTP 404, got nil")
 	}
 	if _, err := os.Stat(dest); err == nil {
 		t.Error("dest exists after failed download")
+	}
+}
+
+// withSmallParallelMin makes the split path reachable without moving 64 MB
+// around in a unit test.
+func withSmallParallelMin(t *testing.T, n int64) {
+	t.Helper()
+	old := parallelMin
+	parallelMin = n
+	t.Cleanup(func() { parallelMin = old })
+}
+
+func TestDownloadParallel(t *testing.T) {
+	// Not a multiple of parallelStreams: the last segment must carry the
+	// remainder, or the file comes back short.
+	payload := bytes.Repeat([]byte("camne"), 481) // 2405 bytes
+	withSmallParallelMin(t, 100)
+
+	var mu sync.Mutex
+	var ranges []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		ranges = append(ranges, r.Header.Get("Range"))
+		mu.Unlock()
+		http.ServeContent(w, r, "f", time.Time{}, bytes.NewReader(payload))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "file.bin")
+	if err := Download(srv.URL, dest, int64(len(payload)), sum(payload)); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest missing: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dest is %d bytes, want %d", len(got), len(payload))
+	}
+	if len(ranges) != parallelStreams {
+		t.Errorf("made %d requests, want %d", len(ranges), parallelStreams)
+	}
+	if n := PartBytes(dest); n != 0 {
+		t.Errorf("%d bytes of partial files left behind, want 0", n)
+	}
+}
+
+// The point of segment files: an interrupted parallel download resumes instead
+// of re-fetching what is already on disk.
+func TestDownloadParallelResumes(t *testing.T) {
+	payload := bytes.Repeat([]byte("camne"), 480) // 2400, 300 per segment
+	withSmallParallelMin(t, 100)
+
+	var mu sync.Mutex
+	var ranges []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		ranges = append(ranges, r.Header.Get("Range"))
+		mu.Unlock()
+		http.ServeContent(w, r, "f", time.Time{}, bytes.NewReader(payload))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "file.bin")
+	// Segment 0 whole, segment 1 half done, segment 7 junk that is too long.
+	if err := os.WriteFile(segPath(dest, 0), payload[0:300], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(segPath(dest, 1), payload[300:450], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(segPath(dest, 7), bytes.Repeat([]byte("x"), 999), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Download(srv.URL, dest, int64(len(payload)), sum(payload)); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest missing: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dest content wrong: %d bytes, want %d", len(got), len(payload))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// The whole segment must not have been asked for again, and the half-done
+	// one must have resumed at its own offset rather than at its start.
+	for _, r := range ranges {
+		if r == "bytes=0-299" {
+			t.Error("re-fetched a segment that was already complete")
+		}
+	}
+	var sawResume bool
+	for _, r := range ranges {
+		if r == "bytes=450-599" {
+			sawResume = true
+		}
+	}
+	if !sawResume {
+		t.Errorf("half-done segment did not resume at its offset; ranges seen: %v", ranges)
+	}
+}
+
+// A server that answers a range request with the whole file cannot be split
+// across connections. Falling back must still produce the right file and leave
+// no segments behind.
+func TestDownloadParallelFallsBackWhenRangeIgnored(t *testing.T) {
+	payload := bytes.Repeat([]byte("camne"), 480)
+	withSmallParallelMin(t, 100)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload) // 200 OK, whole body, Range ignored
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "file.bin")
+	if err := Download(srv.URL, dest, int64(len(payload)), sum(payload)); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest missing: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("dest content wrong: %d bytes, want %d", len(got), len(payload))
+	}
+	if n := PartBytes(dest); n != 0 {
+		t.Errorf("%d bytes of partial files left behind, want 0", n)
+	}
+}
+
+// A server that answers a range request with MORE than the range must not be
+// able to push one segment's bytes over the next segment's.
+func TestDownloadParallelBoundsOverlongResponses(t *testing.T) {
+	payload := bytes.Repeat([]byte("camne"), 480)
+	withSmallParallelMin(t, 100)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var lo, hi int
+		fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &lo, &hi)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", lo, hi, len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[lo:]) // everything from lo, ignoring hi
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "file.bin")
+	if err := Download(srv.URL, dest, int64(len(payload)), sum(payload)); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest missing: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("dest is %d bytes, want %d — segments overran their spans", len(got), len(payload))
+	}
+}
+
+func TestPartBytesCountsEverySegment(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "file.bin")
+	if n := PartBytes(dest); n != 0 {
+		t.Errorf("PartBytes on nothing = %d, want 0", n)
+	}
+	for i := 0; i < 3; i++ {
+		if err := os.WriteFile(segPath(dest, i), make([]byte, 10), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(dest+".part", make([]byte, 5), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Segments and the joined file both count: the progress display must not
+	// dip while one is being turned into the other.
+	if n := PartBytes(dest); n != 35 {
+		t.Errorf("PartBytes = %d, want 35", n)
 	}
 }


### PR DESCRIPTION
## Result

Old binary against new, alternating order, real 986 MB first runs:

```
old 65s     new 23s
new 19s     old 67s
```

**~3.2× faster.** Both orderings agree.

## Why one connection was the limit

The model arrived at 15–17 MB/s on a single stream. The *same file* reaches 62–68 MB/s split eight ways — so the ceiling is per-connection, not bandwidth. Hugging Face reconstructs Xet-backed files server-side for clients speaking plain HTTP, which is every client camne has, and that reconstruction is what one stream waits on.

Three alternating rounds against the pinned model, full 986 MB each:

```
single      58.8s   67.8s   58.8s      median 58.8s
parallel-4  36.8s   20.5s   38.1s      median 36.8s
parallel-8  14.4s   47.1s   15.8s      median 15.8s
```

Every parallel run beat every single-stream run. 8 over 4 on the median, which is why `parallelStreams = 8`.

This also explains the original report that `whatisit` downloads faster. It doesn't — its downloader is the *slower* of the two on an identical URL (66.7s/141.0s against camne's 48.5s/58.2s). Its model simply lives in a repo that reconstructs quickly per-stream. Ours now stops caring.

## What changed

Downloads ≥ 64 MB split into eight ranged requests, each with its own `.partN` file, joined in order once every segment is whole. Below the threshold, and against any server that answers a range with the whole file, the single-stream path runs exactly as before.

Three things deliberately not simplified away:

- **Resume survives.** Segment files are what make that nearly free — each resumes from its own size using the logic the single stream already had. An interrupted 900 MB download still carries on. Losing that would be data loss on a metered connection, which is the connection this tool is for.
- **`verifyAndRename` is untouched.** sha256 over the joined file, before the rename, never after.
- **Segments are bounded by `io.LimitReader`.** A server answering a range with *more* than the range must not overwrite the next segment's bytes. There's a test that makes a server do exactly that.

Joining deletes each segment as it lands, so peak disk is the file plus one segment, not the file twice.

`camne update` passes size 0 — `checksums.txt` carries no length, and a 7 MB binary doesn't want eight connections.

## Progress display

Polls `provision.PartBytes`, which sums every partial file, so the bar means the same thing for one stream, for eight segments, and while they're being joined.

It also drops the speed once every byte is down. Caught from watching a real run, not from the tests: the final frames read `0.0 MB/s` during joining and hashing — a false stall signal, in the one place the rate exists to make stalls honest.

## Verification

- `go test ./...` green; `-race` clean on the new concurrent code
- New tests: split path, resume mid-segment, over-long segment discarded, fallback when Range is ignored, over-long response bounded, `PartBytes` across segments + joined file
- Cross-compiles for linux/arm64, darwin/arm64, windows/amd64
- Real first run: model at 84.8 MB/s

Pre-existing and unrelated: `TestNoReDoS` fails under `-race` on a timing budget the detector's slowdown blows through. Passes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)