### PR TITLE
fix: stop TestShouldCheck expiring on a wall-clock date

### DIFF
--- a/cmd/camne/update_test.go
+++ b/cmd/camne/update_test.go
@@ -139,9 +139,12 @@ func TestShouldCheck(t *testing.T) {
 	}
 
 	// touch on an existing stamp has to move the mtime forward, or the
-	// throttle would only ever work once.
+	// throttle would only ever work once. These two assertions measure a real
+	// mtime, so they take their reference from the real clock — pairing the
+	// frozen `now` above with a real touch made this test expire on
+	// 2026-08-15, when now+48h stopped being 24 h clear of time.Now().
 	touch(fresh)
-	if !shouldCheck("v0.3.1", fresh, true, now.Add(48*time.Hour)) {
+	if !shouldCheck("v0.3.1", fresh, true, time.Now().Add(48*time.Hour)) {
 		t.Error("shouldCheck 48 h after a touch = false, want true")
 	}
 	if shouldCheck("v0.3.1", fresh, true, time.Now()) {


### PR DESCRIPTION
`go test ./...` fails on `main` as of today, with no code change involved:

```
--- FAIL: TestShouldCheck (0.00s)
    update_test.go:145: shouldCheck 48 h after a touch = false, want true
```

## Cause

`TestShouldCheck` freezes `now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)`, but the last two assertions call `touch(fresh)`, which writes the **real** clock. So the interval `shouldCheck` measures is `now.Add(48h) - time.Now()`, and that shrinks by a day for every day that passes.

```
test asserts now+48h = 2026-08-16 12:00
touch sets mtime      = 2026-08-15 13:57   (real clock)
difference seen       = 22.0 h, needs >= 24 h
```

It crossed below `checkInterval` at **2026-08-15 12:00 UTC** and fails on every machine from then on.

`shouldCheck` itself is correct — this is purely the test.

## Fix

Those two assertions exist to prove `touch` moves the mtime forward, which is inherently relative to the real clock, so they now take their reference from it rather than from the frozen `now`.

The table above keeps the frozen `now` deliberately: every one of its cases sets the mtime explicitly with `Chtimes`, so none of them depends on the wall clock. Only the post-`touch` pair did.

One line changed, plus a comment recording the failure mode so it does not come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)