### PR TITLE
fix: the first-try hint names the file, so the first answer is a real command

### DIFF
--- a/cmd/camne/main.go
+++ b/cmd/camne/main.go
@@ -180,7 +180,7 @@ func usage() {
 	fmt.Fprint(os.Stderr, `camne — ask in plain Malay or English, get a shell command.
 
 Use:      camne <your question>
-Examples: camne nak buat file baru
+Examples: camne nak buat file nota.txt
           camne how do I find a file in this folder
 
 Also:     camne doctor   — check what is already installed

--- a/install.sh
+++ b/install.sh
@@ -79,4 +79,4 @@ case ":$PATH:" in
 	*) echo "Note: add $DIR to your PATH first, like this:"
 	   echo "  export PATH=\"\$PATH:$DIR\"" ;;
 esac
-echo "Try it: camne nak buat file baru"
+echo "Try it: camne nak buat file nota.txt"


### PR DESCRIPTION
'nak buat file baru' with no filename still returns a tldr placeholder
(touch path/to/file1 ...); 'nak buat file nota.txt' returns touch note.txt.
The hint in install.sh and the help text is a beginner's first impression;
give it a query the shipped model answers well. Unnamed rows for run 8 are
tracked separately.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
