### PR TITLE
Run 9: pool_v7 caps the long tail and removes placeholder rows (#54)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -822,7 +822,7 @@ out/pool_v7.jsonl`, seed 42, deterministic):**
    list plus every tool basics.txt teaches, plus shell keywords `for`,
    `while`, `if`, `until`, `case`, which are composition, not tools).
    Sampled by whole pair so the four registers of a command stay together.
-   15,754 rows dropped from 61 tools (`az`, `aws`, `kubectl`, `cargo`,
+   15,754 rows dropped from 51 tools (`az`, `aws`, `kubectl`, `cargo`,
    `gh`, `tlmgr`, `pio`, `shuf`, … each 1,200 → 300).
 3. `find` to 5% of the final pool. It is core and genuinely common, but at
    17% it is the answer the model reaches for when unsure; 5% still leaves

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -774,3 +774,99 @@ inside the scorer's own ±5/300. Consequences:
 - Protocol, going into CLAUDE.md § "Model work": one seed suffices when
   the paired CI excludes zero; a delta inside ±0.02 is "no difference",
   never a trend; anything read off a single register at p ≥ 0.05 is noise.
+
+## Run 9: the pool's tool prior (issue #54)
+
+**Hypothesis, written before the run.** Runs 7, 8 and the Qwen3.5-2B arm
+all answer `nak buat file baru` with a tldr placeholder or `fossil add`,
+and run 8 showed that 85 hand rows do not move that. The cause is the
+prior the pool teaches, not a coverage hole: 16% of pool_v6's rows have
+`path/to/...` or `<name>` in the command, `find` alone is 17% of the pool,
+and 4,819 distinct first tokens split the rest, so a prompt that lands
+off-distribution is answered with a placeholder from a tool the model saw
+300 times. Removing the placeholder rows, capping the long tail at 300
+rows per non-core tool and cutting `find` to 5% (`dataset/prior.py`,
+`pool_v7`) will (a) take the placeholder rate on the probe's outputs to
+zero, (b) fix `create file` unnamed (`nak buat file baru`,
+`nak buat satu file baru`, `tolong buat file baru`) with a real filename in
+the answer, and (c) hold ALFA English within run 7's CI. Falsified if the
+probe still emits `path/to` or a long-tail tool for the unnamed prompts —
+then the prior is in the base, not the pool — or if English drops by more
+than the CI, which would mean the 34% of rows removed were carrying
+accuracy (RESULTS.md, run 2, the mistake this cut is closest to
+repeating).
+
+One variable changed from run 7: the pool. `pool_v7 = prior.py(pool_v6)`,
+where `pool_v6 = pool_v4.bal + basics.jsonl` at 330 tasks; the 85 unnamed
+rows from #47 are in, so against run 7 the pool differs by the prior fix
+plus those rows, and against run 8 by the prior fix alone. Same recipe,
+seed 42, 1 epoch. Probe prompts unchanged, none verbatim in basics.txt.
+
+**What prior.py does, in order (`python3 prior.py out/pool_v6.jsonl
+out/pool_v7.jsonl`, seed 42, deterministic):**
+
+1. Placeholders. `path/to/...` and `<name>` in the command. Where every
+   placeholder also appears verbatim in the NL — the user typed the path,
+   `senarai folder kat /path/to/dir` → `find /path/to/dir -type d` — both
+   sides are rewritten to one concrete name (`path/to/dir` → `projek`,
+   `<file>` → `notes.txt`, otherwise the last path component) so the pair
+   stays consistent and `path/to` leaves the output vocabulary. Where the
+   NL never named it (every tldr `Create specific files` → `touch
+   path/to/file1 path/to/file2`), or there is no safe name (`<port>`,
+   `<package>`), the row is dropped. Keystrokes (`<Ctrl x>`, `<Enter>`,
+   `<q>`) are not placeholders and stay. 1,012 rows rewritten, 55,246
+   dropped. Rewritten commands are the only ones in the pool not
+   byte-identical to source; the diff is the placeholder token and nothing
+   else.
+2. Cap. 300 rows per first token for tools outside CORE (rebalance.py's
+   list plus every tool basics.txt teaches, plus shell keywords `for`,
+   `while`, `if`, `until`, `case`, which are composition, not tools).
+   Sampled by whole pair so the four registers of a command stay together.
+   15,754 rows dropped from 61 tools (`az`, `aws`, `kubectl`, `cargo`,
+   `gh`, `tlmgr`, `pio`, `shuf`, … each 1,200 → 300).
+3. `find` to 5% of the final pool. It is core and genuinely common, but at
+   17% it is the answer the model reaches for when unsure; 5% still leaves
+   it the single largest tool. 46,364 rows dropped. basics rows are exempt
+   from every rule.
+
+| | pool_v6 (run 8) | **pool_v7** |
+|---|---|---|
+| rows | 345,721 | **228,357** (−34%) |
+| distinct first tokens | 4,819 | 4,102 |
+| top-30 share | 35.3% | 29.4% |
+| rows with a placeholder in cmd | 56,258 (16.3%) | **0** |
+| `find` share | 16.9% (58,365) | 5.0% (11,484) |
+| `touch` / `mkdir` / `useradd` | 535 / 959 / 116 | 454 / 918 / 104 |
+| `az` / `aws` / `kubectl` / `shuf` | 1,200 each | 300 each |
+| `fossil` / `skicka` / `kcadm.sh` | 151 / 66 / 38 | 91 / 0 / 30 |
+| by source (nl2sh_train / tldr / extra / basics) | 187,891 / 95,848 / 59,401 / 2,581 | 109,995 / 66,758 / 49,047 / 2,581 |
+
+The `touch` rows lost are exactly the placeholder ones; every surviving
+`touch` names a real file. `nl2sh_train` lost the most: 26,869 of its
+rows carried `path/to` because that pool was itself partly tldr-derived.
+
+**Hand-read, 200 rows, `random.Random(42).sample`.** Registers read as
+intended: colloquial and rojak natural (`tlg buang all file _* and
+.DS_Store`, `nak tengok status semua job je kat sini`), formal circular-ish
+by design. Nothing prior.py rewrote read wrong (30 rewritten rows read
+separately: `Remount "bin"` and `mount device location` are dull but
+consistent on both sides). What did read wrong is older pool noise, none of
+it in this issue's scope, all counted so it can be its own issue: 246 rows
+whose command starts with a `$ ` prompt (`$ find /dev ...`, first token
+`$`); 11,779 rows (5%) with tldr's alternation syntax in the command
+(`ctest [-j|--parallel] 4`, `komac bash|elvish|fish|zsh`), which is not a
+runnable command; 139 `path\to\key` (wine reg, backslashes); 217
+`some_command`/`command1` placeholders; 48 rows where NL is the command
+itself; a few Indonesian slips (`kota`, `acak`) the stoplist does not
+know; and a handful of mismatched `extra` pairs (`Hapus entri dalam fail
+.bash_history` → `export HISTCONTROL=ignoreboth`).
+
+**Measure.** Run 7 to beat: ALFA BM 0.487 / rojak 0.490 / EN 0.543, probe
+basics 0.90 / holdout 0.78; run 8 for the same-rows comparison. New
+number: placeholder rate on the probe outputs (`path/to` or `<name>` in the
+answer), reported alongside. Then #47's exact-output prompts, `compare.py`
+vs run 7, bench, all with #57's error bar in mind.
+
+GPU command, from the worktree's `training/`:
+`./rebuild.sh qwen-v7 ../dataset/out/pool_v7.jsonl` — queued behind the
+running job, one at a time (#56, #57).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -870,3 +870,40 @@ vs run 7, bench, all with #57's error bar in mind.
 GPU command, from the worktree's `training/`:
 `./rebuild.sh qwen-v7 ../dataset/out/pool_v7.jsonl` — queued behind the
 running job, one at a time (#56, #57).
+
+**Result (2026-08-17): the pool prior moves the probe, not ALFA.** `qwen-v7`,
+228,357 rows, 2 h 40 min train on the 3090. Error bar from #57: same recipe
+reproduces to ≤ 0.013 per register.
+
+| register | run 7 | run 9 (v7) | diff | 95% CI | lost / gained | p |
+|---|---|---|---|---|---|---|
+| BM | 0.487 | 0.513 | +0.027 | [−0.029, +0.083] | 33 / 41 | 0.42 |
+| rojak | 0.490 | 0.517 | +0.027 | [−0.026, +0.080] | 29 / 37 | 0.39 |
+| EN | 0.543 | 0.563 | +0.020 | [−0.036, +0.076] | 34 / 40 | 0.56 |
+
+All three registers up, none clears its CI. The churn is the story: ~35
+tasks lost and ~40 gained per register — ten times run 7 vs v5b — so a
+34% pool cut is a different model, and 300 tasks cannot say whether it is
+a better one. English did not drop, so the run-2 fear did not come true.
+
+Probe: 199 / 222 both, not the same 199. What the issue was for is fixed:
+`create file` 8/9 → 9/9 (`touch newfile.txt` on every phrasing, no more
+`fossil add path/to/file`), `create folder` 8/8, `create user` 2/5 → **5/5**
+(`sudo useradd -m newuser`, no more `kcadm.sh`), placeholder answers
+29 → **6** across the 222 prompts. What broke: `delete file` ×4 →
+`git obliterate file_1 file_2 ...` (was `rm path/to/file1 ...`, tool-right
+placeholder), `list processes` ×3 → `pm2 list`/`pm2 monit` (was `ps aux`),
+`edit file` → `less`, holdout 36 → 33 (`chsh`, `timeout`, `whereis` lost;
+`tee` ×2, `reverse lines/en` gained). `rm` and `ps` rows barely moved
+(1,618 → 1,539, 928 → 868); what moved is share — the core list is
+uncapped, so `git` went from 4.3% to 5.8% of the pool and `pm2` (84 rows,
+under the cap) from 0.02% to 0.04%. Capping the tail without growing the
+head redistributes the prior, it does not flatten it. Bench unchanged
+(4 threads 0.53 s warm, 39 tok/s, 1.49 GB RSS).
+
+Verdict: not shipping on ALFA alone (inside CI, per #57's protocol), but
+the probe targets #47/#53/#54 exist for are met on this pool. The next
+pool change should add head rows for the beginner verbs (`rm`, `ps`,
+`nano`) rather than cut more tail — and #56's DPO pairs already encode
+exactly the `git obliterate`/`pm2` class of miss, so DPO on this
+checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`) is the cheap next arm.

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -20,6 +20,10 @@ augment_verbs.py  # → out/pool_v3.aug.jsonl    fill in Malay verbs the
                   # translator never reached for (`cipta` had 2 rows)
 rebalance.py      # → out/pool_v3.bal.jsonl    fix the tool-frequency
                   # inversion (`shuf` outweighed `touch` 11 to 1)
+basics.py         # basics.txt → out/basics.jsonl  hand-written beginner rows
+prior.py          # pool_v6 (= pool_v4.bal + basics) → out/pool_v7.jsonl
+                  # drop/rewrite path/to placeholders, cap the long tail at
+                  # 300, find to 5% (issue #54)
 ```
 
 Full rebuild from raw, no GPU:

--- a/dataset/prior.py
+++ b/dataset/prior.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fix the pool's tool prior (issue #54). Stdlib only.
+
+  python3 prior.py out/pool_v6.jsonl out/pool_v7.jsonl
+
+pool_v6 is pool_v4.bal + basics.jsonl. Three tuned models answered `nak buat
+file baru` with `touch path/to/file1 path/to/file2` or `fossil add`: 14.7%
+of rows carry a tldr placeholder in the command, `find` is 17% of the pool
+and 4,800 distinct first tokens split the rest. Three rules, in this order:
+
+  placeholders  `path/to/...` and `<name>` in the command. If every one also
+                appears verbatim in the NL (the user typed the path), rewrite
+                both sides to a concrete name so the pair stays consistent
+                and `path/to` leaves the output vocabulary. Otherwise the NL
+                never named what the command names — drop. Keystrokes
+                (`<Ctrl c>`, `<Enter>`, `<q>`) are not placeholders and stay.
+  --cap N       rows per first token for tools outside CORE (rebalance.py's
+                list plus every tool basics.txt teaches). Whole pairs are
+                sampled, seed 42, so the four registers stay together.
+  --find-share  `find` is core and genuinely common, but 17% is a prior no
+                task set has; a model that is unsure reaches for it. Sampled
+                down to this share of the final pool.
+
+basics.jsonl rows are never dropped. Rewritten commands are the only ones
+not byte-identical to source; the rewrite touches nothing but the
+placeholder token, and the same token in the NL.
+"""
+import argparse
+import json
+import random
+import re
+from collections import Counter, defaultdict
+
+from basics import parse
+from rebalance import CORE, tool
+
+# Shell keywords are not tools; a loop is composition, not a long-tail prior.
+KEYWORDS = {"for", "while", "if", "until", "case"}
+NAMES = {"file": "notes.txt", "filename": "notes.txt", "directory": "projek",
+         "dir": "projek", "folder": "projek"}
+KEYS = {"ctrl", "alt", "shift", "esc", "escape", "enter", "return", "space",
+        "tab", "backspace", "del", "delete", "up", "down", "left", "right",
+        "home", "end", "pageup", "pagedown", "pgup", "pgdn", "super", "cmd",
+        "meta", "fn", "insert", "cr"} | {f"f{i}" for i in range(1, 13)}
+PATH = re.compile(r"path/to/[\w./-]*\w")
+ANGLE = re.compile(r"<[A-Za-z][\w -]+>")   # `<q>`, `<p>` are a key / a tag
+
+
+def concrete(ph):
+    """`path/to/dir_a` -> `dir_a`, `<file>` -> `notes.txt`; None = no safe name."""
+    if ph.startswith("<"):
+        name = ph[1:-1].split()[0].lower()
+        return None if name in KEYS else NAMES.get(name)
+    name = ph.rstrip("/").split("/")[-1]
+    return NAMES.get(name, name)
+
+
+def rewrite(nl, cmd):
+    """(nl, cmd) with placeholders made concrete, or None to drop."""
+    phs = PATH.findall(cmd) + [p for p in ANGLE.findall(cmd)
+                               if p[1:-1].split()[0].lower() not in KEYS]
+    if any(ph not in nl or concrete(ph) is None for ph in phs):
+        return None
+    for ph in dict.fromkeys(phs):
+        # `/path/to/x` and `path/to/x` alike; `/remote/path/to/x` keeps `/remote/`
+        pat = r"(?:(?<![\w/])/)?" + re.escape(ph)
+        nl, cmd = re.sub(pat, concrete(ph), nl), re.sub(pat, concrete(ph), cmd)
+    if "path/to" in cmd:              # `path/to/*.txt`, `path/to new/dir`
+        return None
+    return nl, cmd
+
+
+def sample_ids(rows, keep_rows, seed=42):
+    """Deterministic pair-level cut: ids to keep so that ~keep_rows survive."""
+    by_id = defaultdict(int)
+    for r in rows:
+        by_id[r["id"]] += 1
+    ids = sorted(by_id)
+    random.Random(seed).shuffle(ids)
+    kept, n = set(), 0
+    for i in ids:
+        if n >= keep_rows:
+            break
+        kept.add(i)
+        n += by_id[i]
+    return kept
+
+
+def report(label, rows):
+    cnt = Counter(tool(r["cmd"]) for r in rows)
+    top30 = sum(n for _, n in cnt.most_common(30))
+    ph = sum(1 for r in rows if rewrite(r["nl"], r["cmd"]) != (r["nl"], r["cmd"]))
+    print(f"{label}: {len(rows)} rows, {len(cnt)} first tokens, "
+          f"top-30 share {100*top30/len(rows):.1f}%, placeholders {ph}, "
+          f"find {100*cnt['find']/len(rows):.1f}%")
+    return cnt
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--cap", type=int, default=300)
+    ap.add_argument("--find-share", type=float, default=0.05)
+    ap.add_argument("--basics", default="basics.txt")
+    args = ap.parse_args()
+
+    rows = [json.loads(l) for l in open(args.src, encoding="utf-8")]
+    before = report("before", rows)
+    core = set(CORE) | KEYWORDS | {tool(cmd) for cmd, _ in parse(args.basics)}
+    hand = lambda r: r["id"].startswith("basics:")
+
+    # 1. placeholders
+    kept, rewritten, dropped_ph = [], 0, 0
+    for r in rows:
+        got = rewrite(r["nl"], r["cmd"])
+        if got is None:
+            dropped_ph += 1
+            continue
+        if got != (r["nl"], r["cmd"]):
+            rewritten += 1
+            r = {**r, "nl": got[0], "cmd": got[1]}
+        kept.append(r)
+    rows = kept
+
+    # 2. cap the long tail, whole pairs
+    by_tool = defaultdict(list)
+    for r in rows:
+        by_tool[tool(r["cmd"])].append(r)
+    keep_ids = set()
+    for t in sorted(by_tool):
+        rs = by_tool[t]
+        if t in core or len(rs) <= args.cap:
+            keep_ids.update(r["id"] for r in rs)
+        else:
+            keep_ids |= sample_ids(rs, args.cap)
+    kept = [r for r in rows if hand(r) or r["id"] in keep_ids]
+    dropped_cap = len(rows) - len(kept)
+    rows = kept
+
+    # 3. find down to --find-share of the final pool
+    finds = [r for r in rows if tool(r["cmd"]) == "find" and not hand(r)]
+    others = len(rows) - len(finds)
+    want = int(others * args.find_share / (1 - args.find_share))
+    keep_ids = sample_ids(finds, want) if len(finds) > want else {r["id"] for r in finds}
+    kept = [r for r in rows if hand(r) or tool(r["cmd"]) != "find" or r["id"] in keep_ids]
+    dropped_find = len(rows) - len(kept)
+    rows = kept
+
+    print(f"placeholders: rewrote {rewritten}, dropped {dropped_ph}; "
+          f"cap {args.cap}: dropped {dropped_cap}; "
+          f"find -> {args.find_share:.0%}: dropped {dropped_find}")
+    after = report("after", rows)
+    for t in ("find", "touch", "mkdir", "useradd", "tar", "az", "aws", "kubectl",
+              "shuf", "fossil", "skicka", "kcadm.sh", "ss", "lsof"):
+        print(f"  {t:10s} {before.get(t,0):>7} -> {after.get(t,0):>7}")
+    with open(args.dst, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"wrote {len(rows)} rows -> {args.dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dataset/test_pipeline.py
+++ b/dataset/test_pipeline.py
@@ -219,3 +219,36 @@ _by = {}
 for _r in _b:
     _by.setdefault(_r["id"].split(".")[0], set()).add(_r["cmd"])
 assert all(len(v) == 1 for v in _by.values())
+
+# --- prior.py (issue #54: placeholder rewrite + long-tail cap) --------------
+from prior import rewrite, sample_ids
+
+for nl, cmd, want in (
+        # user typed the path: rewrite both sides, `path/to` leaves the command
+        ("senarai folder kat /path/to/dir", "find /path/to/dir -type d",
+         ("senarai folder kat projek", "find projek -type d")),
+        ("copy /path/to/data/app ke host:/remote/path/to/data/app",
+         "rsync -r /path/to/data/app host:/remote/path/to/data/app",
+         ("copy app ke host:/remote/app", "rsync -r app host:/remote/app")),
+        ("nak tengok fail <file>", "ncdu -f <file>", ("nak tengok fail notes.txt", "ncdu -f notes.txt")),
+        # NL never named it: drop
+        ("Create specific files", "touch path/to/file1 path/to/file2", None),
+        ("nak update package ni", "snap refresh <package>", None),
+        # NL names it but there is no safe concrete name for `<port>`: drop
+        ("proses kat port <port>", "netstat -pln | grep <port>", None),
+        # unmatched placeholder shapes: drop
+        ("delete files on the server", "mrm path/to/*.txt", None),
+        # keystrokes and HTML tags are not placeholders
+        ("nak keluar nano", "<Ctrl x>", ("nak keluar nano", "<Ctrl x>")),
+        ("quit less", "<q>", ("quit less", "<q>")),
+        ("first paragraph", "grep -o '<p>[^<]*</p>' page.html", ("first paragraph", "grep -o '<p>[^<]*</p>' page.html")),
+        ("nothing to do", "ls -la", ("nothing to do", "ls -la"))):
+    assert rewrite(nl, cmd) == want, (nl, cmd, rewrite(nl, cmd))
+
+# cap: whole pairs, deterministic, lands at or just past the target
+_rows = [{"id": f"t:{i}", "register": reg} for i in range(50)
+         for reg in ("formal", "colloquial", "rojak", "english")]
+_k = sample_ids(_rows, 30)
+assert _k == sample_ids(_rows, 30) and 30 <= 4 * len(_k) < 34, _k
+assert sample_ids(_rows, 1000) == {f"t:{i}" for i in range(50)}
+print("ok: prior checks pass")


### PR DESCRIPTION
Part of #54 (dataset + one run). Stacked on #57's PR; retarget to main once that merges.

`dataset/prior.py` builds `pool_v7` from `pool_v6`: cap 300 rows per non-core first token, drop or consistently rewrite `path/to`/`<name>` rows, `find` 17% → 5%. 345,721 → 228,357 rows (−34%), 0 placeholder commands. 200-row hand read in RESULTS.md.

Run 9 (`qwen-v7`) vs run 7:

| register | run 7 | run 9 | diff | 95% CI | p |
|---|---|---|---|---|---|
| BM | 0.487 | 0.513 | +0.027 | [−0.029, +0.083] | 0.42 |
| rojak | 0.490 | 0.517 | +0.027 | [−0.026, +0.080] | 0.39 |
| EN | 0.543 | 0.563 | +0.020 | [−0.036, +0.076] | 0.56 |

Inside CI on every register; ~35 lost / ~40 gained per register. Probe placeholders 29 → 6, `create user` 2/5 → 5/5, but `delete file` → `git obliterate` and `list processes` → `pm2` (share redistributed, not flattened). Not shipping on its own; see #56's PR for DPO on this checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
