### PR TITLE
DPO on the model's own mistakes, two arms, neither clears the CI (#56)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -907,3 +907,73 @@ pool change should add head rows for the beginner verbs (`rm`, `ps`,
 `nano`) rather than cut more tail — and #56's DPO pairs already encode
 exactly the `git obliterate`/`pm2` class of miss, so DPO on this
 checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`) is the cheap next arm.
+
+
+## Run qwen-v5-dpo: DPO on the model's own mistakes (issue #56)
+
+**Hypothesis, written before the run.** Every SFT run so far has taught the
+model what to say and nothing about what not to say. Run 7's remaining
+misses are not coverage holes, they are near-misses on the same tokens the
+pool teaches: `touch path/to/file1 path/to/file2 ...` (right tool, tldr
+placeholder — 50,878 of the 345,636 pool rows carry `path/to`), and a
+same-pool obscure tool where the pool has a common one (`fossil add`,
+`skicka mkdir`, `kcadm.sh create users`, `lzop`, `gdu`, `fkill`, `smem`).
+Run 8 tried to fix these by adding rows and moved BM by −0.06 instead. A
+DPO stage that holds the gold as chosen and those exact outputs as rejected
+pushes against the failure directly, without adding rows to the SFT pool or
+changing its order. Prediction: on the shipped CPU path the placeholder
+rate on the probe's 177 basics-task prompts falls from **24/177 (0.14)** to
+under 0.03, `nak buat file baru` returns `touch newfile.txt` (or any
+`touch` with a real name), `nak buat user baru` returns `useradd`, and the
+three ALFA registers stay inside their run 7 CIs (BM 0.487, rojak 0.490,
+EN 0.543). Falsified if any ALFA register drops with p < 0.05 — then the
+preference stage is trading beginner exactness for one-liner accuracy and
+β or the pair mix is next — or if the placeholder rate does not move, which
+would mean 3,455 pairs at β = 0.1 do not shift a preference that 15% of the
+pool voted for.
+
+One variable vs run 7: the DPO stage. `training/dpo.py` puts a fresh
+r32/a64 LoRA on the run 7 merged checkpoint (`out/qwen-v5-lora-merged`),
+TRL `DPOTrainer`, sigmoid loss, β = 0.1, 1 epoch, seed 42, effective batch
+32, lr 5e-6 (Unsloth's DPO reference recipe; SFT's 2e-4 would wreck the
+policy), reference = the same weights with the adapter disabled. Prompt
+text is train.py's literal ChatML. Same GGUF path as every run
+(`finish.sh` → f16 → Q4_K_M), same pinned CPU probe. `trl` 0.24.0 was
+already in `uv.lock` (unsloth pulls it); nothing was added.
+
+**Pairs, `training/dpo_pairs.py` → `out/dpo_pairs.jsonl`, 3,455 total:**
+
+| kind | n | chosen | rejected |
+|---|---|---|---|
+| probe-wrong | 18 | basics.txt command for the probe task | run 7's actual output (`gdu --disk-usage`, `fkill :8080`, `kcadm.sh create users ...`, `jobs`, `smem --memstats`, `tempdir -c` ...) |
+| probe-placeholder | 22 | same | run 7's tool-level pass that was a placeholder (`touch path/to/file1 path/to/file2 ...`, `skicka mkdir path/to/folder`, `rm path/to/file1 ...`, `chmod 644 /path/to/file`) |
+| synth-placeholder | 999 | basics.txt gold, every phrasing | gold with names swapped for `path/to/file` / `path/to/directory` |
+| synth-tool-swap | 2,416 | basics.txt gold, every phrasing | gold's tool swapped for what run 7 reached for (`touch`→`fossil add`, `mkdir`→`skicka mkdir`, `useradd`→`kcadm.sh create users`, `tar`→`lzop`, `df`→`gdu`, `kill`→`fkill`, `free`→`smem`) or a low-count pool tool drawn with seed 42 |
+
+Unweighted: the 40 real-mistake pairs are 1.2% of the set. If the probe
+misses persist while the synthetic kinds land, weighting the real pairs is
+the next variable, not a bigger β.
+
+**Split, stated.** ALFA is not touched: no pair is built from any ALFA
+task, and the three basics.txt English phrasings that are verbatim
+nl2sh_test prompts (`print hello world`, `print the current user`, `list
+all users on the system`) are dropped from the pair set. The probe main
+block is **not** clean after this run: the 40 probe-* pairs train on the
+probe's own prompts, so post-DPO basics-task numbers measure recall of the
+fix, not phrasing generalisation; read them as "did the specific miss go
+away", and read the ALFA and HOLDOUT columns for generalisation. HOLDOUT
+(no basics.txt command to serve as chosen) and the homograph guard get no
+pairs and stay clean. Homograph EN-sense (`fails` = failure) is the
+regression to watch: `nak buat fail baru` → `touch` is now a chosen row.
+
+Measured before the run (run 7, shipped model, pinned CPU build): probe
+basics 0.90 / holdout 0.78 / homograph 1.00 / 0.67, placeholder rate 24/177
+on basics prompts and 25/223 overall, ALFA BM 0.487 / rojak 0.490 / EN
+0.543, bench 4 threads 36.8 tok/s / 0.57 s warm / 1.38 s cold / 1626 MB.
+#47 prompts exact: see the run 8 table above (run 7 column).
+
+Order: queued behind #54's retrain. If #54 ships, `DPO_BASE=out/<54
+merged>` puts this stage on top of it and the comparison row becomes #54's
+run instead of run 7; the pairs are rebuilt from that run's probe file
+(`dpo_pairs.py --probe out/probe_<54>.jsonl`). Not started; hypothesis
+written first.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -977,3 +977,58 @@ merged>` puts this stage on top of it and the comparison row becomes #54's
 run instead of run 7; the pairs are rebuilt from that run's probe file
 (`dpo_pairs.py --probe out/probe_<54>.jsonl`). Not started; hypothesis
 written first.
+
+**Result (2026-08-17): both DPO arms ran; the hypothesis is falsified on
+run 7 and half-met on the pool_v7 checkpoint.** Each DPO stage is 3 min on
+the 3090 (3,4xx pairs, 1 epoch), reward accuracy 0.99 by the end — the
+pairs are learned; the question was whether that generalises. #57's error
+bar (≤ 0.013 same-recipe) applies.
+
+*Arm A — `qwen-v5-dpo`, on run 7's merged checkpoint, pairs from run 7's
+probe (3,455):*
+
+| register | run 7 | run 7 + DPO | diff | 95% CI | lost / gained | p |
+|---|---|---|---|---|---|---|
+| BM | 0.487 | 0.497 | +0.010 | [−0.023, +0.043] | 11 / 14 | 0.69 |
+| rojak | 0.490 | 0.510 | +0.020 | [−0.016, +0.056] | 12 / 18 | 0.36 |
+| EN | 0.543 | 0.530 | −0.013 | [−0.051, +0.025] | 19 / 15 | 0.61 |
+
+Probe 199 → 205 / 222, holdout 36 → 36. Placeholder answers **29 → 23**:
+`nak buat file baru` is now `touch path/to/file1 path/to/file2 ...`
+instead of `fossil add path/to/file` — the tool moved, the placeholder did
+not, although exactly that string is a rejected row. `create user` 2 → 3
+of 5, `kill process on port` gains ×2 (`fuser -k 8080/tcp`). Falsified:
+the placeholder rate went 0.13 → 0.10, not below 0.03; ALFA is inside
+every CI. Bench 0.65 s warm at 4 threads (was 0.47; retest before reading
+anything into it), 1.49 GB.
+
+*Arm B — `qwen-v7-dpo`, on run 9's checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`),
+pairs rebuilt from run 9's probe (3,430):*
+
+| register | run 9 (v7) | v7 + DPO | diff | 95% CI | p | vs run 7 |
+|---|---|---|---|---|---|---|
+| BM | 0.513 | 0.497 | −0.017 | [−0.054, +0.021] | 0.49 | +0.010, p 0.82 |
+| rojak | 0.517 | 0.517 | 0.000 | [−0.032, +0.032] | 1 | +0.027, p 0.40 |
+| EN | 0.563 | 0.543 | −0.020 | [−0.057, +0.017] | 0.38 | 0.000, p 1 |
+
+Probe 199 → **205** / 222, holdout 33 → 34, placeholders **6 → 2**.
+Run 9's regressions come back: `delete file` 2 → 5 of 6 (`rm filename`,
+`git obliterate` gone on three of four phrasings), `list processes` 0 → 2
+of 4 (`ps aux`, `pm2` gone on two). Lost: `change permission` ×2 →
+`icacls file_or_directory` (Windows tool, tldr row; not in the pair set —
+DPO pushed `chmod` down for reasons the pairs do not name), `change
+shell/rojak`. Bench 0.43 s warm at 4 threads, 1.5 GB.
+
+Reading. DPO on ~40 real mistakes plus 3,400 synthetic pairs does what the
+pairs literally say — the specific `fossil`/`kcadm.sh`/`git obliterate`/
+`pm2` misses it was shown flip back — and nothing further: the placeholder
+habit survives on run 7 (23 answers), ALFA does not move on either base,
+and every gain is offset by a new obscure-tool miss elsewhere (`icacls`).
+Three minutes of preference tuning cannot fix a prior that 345k SFT rows
+set; it can only patch the misses it was handed. Neither arm ships:
+v7-dpo has the best probe (205, 2 placeholders, all #47 targets pass) but
+is inside run 7's CI on every register and −0.02 EN on its own base.
+
+Next, if this thread continues: weight the real-mistake pairs (1.2% of the
+set today), or grow the head of the pool for the beginner verbs (#54's
+note) and DPO on top of that — the pool sets the prior, DPO trims it.

--- a/training/dpo.py
+++ b/training/dpo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""DPO stage on top of a merged SFT checkpoint (issue #56).
+
+  uv run dpo.py                                   # run 7 merged -> out/qwen-v5-dpo-lora
+  uv run dpo.py --base-ckpt out/X-lora-merged --data out/dpo_pairs.jsonl --out out/X-dpo-lora
+  ./finish.sh out/qwen-v5-dpo-lora-merged qwen-v5-dpo
+
+One variable vs the SFT run it sits on: this stage. Fresh LoRA (same
+r32/a64/all-linear as train.py) on the merged checkpoint, TRL DPOTrainer,
+sigmoid loss, beta 0.1, 1 epoch, seed 42, effective batch 32. Reference
+model is the same weights with the adapter disabled (TRL's default for
+PEFT), so no second copy in VRAM. bf16 LoRA, not QLoRA.
+
+Pairs come from dpo_pairs.py: {prompt, chosen, rejected}. The prompt is
+wrapped in the same literal ChatML as train.py; chosen/rejected are the bare
+commands and TRL appends eos (<|im_end|> for Qwen) itself, so the training
+text is byte-identical in shape to the SFT rows.
+"""
+import argparse
+import json
+
+from unsloth import FastLanguageModel, PatchDPOTrainer  # before transformers
+from datasets import Dataset
+from trl import DPOConfig, DPOTrainer
+
+from train import CHATML, SYSTEM
+
+PatchDPOTrainer()
+PROMPT = CHATML.split("{cmd}")[0]   # ChatML up to and including "assistant\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-ckpt", default="out/qwen-v5-lora-merged")
+    ap.add_argument("--data", default="out/dpo_pairs.jsonl")
+    ap.add_argument("--out", default="out/qwen-v5-dpo-lora")
+    ap.add_argument("--micro-batch", type=int, default=8,
+                    help="DPO holds chosen+rejected+ref per row; keep the product 32")
+    ap.add_argument("--grad-accum", type=int, default=4)
+    ap.add_argument("--lr", type=float, default=5e-6,
+                    help="Unsloth's DPO reference recipe; SFT's 2e-4 would wreck the policy")
+    args = ap.parse_args()
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        args.base_ckpt, max_seq_length=192, dtype=None, load_in_4bit=False,
+    )
+    model = FastLanguageModel.get_peft_model(
+        model, r=32, lora_alpha=64, lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+        use_gradient_checkpointing="unsloth", random_state=42,
+    )
+
+    rows = [json.loads(l) for l in open(args.data, encoding="utf-8")]
+    ds = Dataset.from_list([{
+        "prompt": PROMPT.format(sys=SYSTEM, nl=r["prompt"]),
+        "chosen": r["chosen"], "rejected": r["rejected"],
+    } for r in rows]).shuffle(seed=42)
+    print(f"{len(ds)} pairs from {args.data}")
+
+    trainer = DPOTrainer(
+        model=model, ref_model=None, processing_class=tokenizer, train_dataset=ds,
+        args=DPOConfig(
+            output_dir=args.out,
+            beta=0.1,
+            loss_type="sigmoid",
+            per_device_train_batch_size=args.micro_batch,
+            gradient_accumulation_steps=args.grad_accum,
+            num_train_epochs=1,
+            learning_rate=args.lr,
+            lr_scheduler_type="cosine",
+            warmup_ratio=0.03,
+            max_prompt_length=128,
+            max_completion_length=64,
+            max_length=192,
+            bf16=True,
+            seed=42,
+            logging_steps=10,
+            save_strategy="epoch",
+            report_to="none",
+        ),
+    )
+    trainer.train()
+
+    # merged bf16 checkpoint; finish.sh takes it from here
+    model.save_pretrained_merged(args.out + "-merged", tokenizer, save_method="merged_16bit")
+    print(f"merged model at {args.out}-merged")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/dpo_pairs.py
+++ b/training/dpo_pairs.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Preference pairs from the model's own mistakes (issue #56). Stdlib only.
+
+  python3 dpo_pairs.py                       # -> out/dpo_pairs.jsonl
+  python3 dpo_pairs.py --probe out/probe_X.jsonl
+
+SFT teaches what to say; DPO can also teach what not to say. Three kinds of
+pair, every one {prompt, chosen, rejected, kind}:
+
+  probe-wrong        probe prompt run 7 failed; chosen = the basics.txt
+                     command for that probe task, rejected = what it printed
+  probe-placeholder  probe prompt it passed tool-level but answered with a
+                     tldr `path/to/...` placeholder; same chosen/rejected rule
+  synth-placeholder  every basics.txt row; rejected = the gold with its
+                     names swapped for `path/to/file` / `path/to/directory`
+  synth-tool-swap    every basics.txt row; rejected = the gold with its tool
+                     swapped for an obscure tool that exists in the pool
+                     (`fossil add`, `skicka mkdir`, `kcadm.sh` — the ones run 7
+                     actually reached for — or one drawn from OBSCURE, seed 42)
+
+Split, stated: ALFA is never touched. Any pair whose prompt is an
+eval_bm_300 / eval_rojak_300 / nl2sh_test prompt is dropped (three basics.txt
+English phrasings collide with nl2sh_test), so the ALFA numbers stay clean.
+The probe is NOT clean after this: probe-* pairs train on the probe's own
+prompts, so post-DPO probe basics-task numbers measure recall, not
+generalisation. HOLDOUT (no basics.txt command to use as
+chosen) and the homograph guard get no pairs and stay clean.
+"""
+import argparse
+import collections
+import csv
+import json
+import os
+import random
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "dataset"))
+from basics import parse as parse_basics  # noqa: E402
+
+# probe.py task -> the basics.txt command for it, with the probe's own names
+# (readme.txt, invoice.pdf, 10.0.0.5 ...) where the prompt carries one.
+GOLD = {
+    "create file": "touch newfile.txt",
+    "create folder": "mkdir newfolder",
+    "delete file": "rm notes.txt",
+    "list files": "ls",
+    "copy file": "cp report.pdf /tmp",
+    "rename file": "mv old.txt new.txt",
+    "disk space": "df -h",
+    "list processes": "ps aux",
+    "kill process on port": "kill $(lsof -t -i:8080)",
+    "open firewall port": "sudo ufw allow 22",
+    "change permission": "chmod +x script.sh",
+    "create user": "sudo useradd -m newuser",
+    "compress folder": "tar -czf folder.tar.gz folder",
+    "search text in files": 'grep -r "error" .',
+    "download a url": "wget https://example.com/a.txt",
+    "read file": "cat readme.txt",
+    "find file by name": "find . -name invoice.pdf",
+    "where am i": "pwd",
+    "my ip": "ip a",
+    "edit file": "nano readme.txt",
+    "exit vim": "<Esc>:q<Enter>",
+    "exit nano": "<Ctrl x>",
+    "extract archive": "tar -xzf data.tar.gz",
+    "move file": "mv report.pdf Documents/",
+    "count lines": "wc -l data.csv",
+    "check internet": "ping -c 4 8.8.8.8",
+    "git commit": 'git commit -m "add login"',
+    "install package": "sudo apt install htop",
+    "run script": "bash deploy.sh",
+    "follow log": "tail -f server.log",
+    "ram usage": "free -h",
+    "ssh into server": "ssh ariff@10.0.0.5",
+    "history": "history",
+    "empty folder delete": "rmdir temp",
+    "copy folder": "cp -r website website_old",
+}
+
+# What run 7 actually answered with (probe_qwen-v5, RESULTS.md run 8 table).
+KNOWN_SWAP = {
+    "touch": "fossil add", "mkdir": "skicka mkdir",
+    "useradd": "kcadm.sh create users", "tar": "lzop", "df": "gdu",
+    "du": "gdu", "kill": "fkill", "pkill": "fkill", "free": "smem",
+    "ps": "jobs", "rmdir": "tempdir -c", "whereis": "whereis -f",
+}
+# Obscure tools that exist in the pool (asserted against --pool at start).
+OBSCURE = ["fossil", "skicka", "kcadm.sh", "fkill", "gdu", "lzop", "smem",
+           "abduco", "croc", "duf", "dust", "procs", "tmsu", "xh", "skate",
+           "atool", "unar", "lsd", "eza", "bfs"]
+
+DIR_TOOLS = {"mkdir", "rmdir", "cd", "ls", "tree", "du"}
+FILE_TOK = re.compile(r"^[\w./-]*\w\.[a-z][a-z0-9]{0,4}$")
+HOST_TOK = re.compile(r"\.(com|org|net|io|me|dev|my)$")
+
+
+def split_tool(cmd):
+    """(prefix, tool, rest) — prefix is 'sudo ' or ''; tool is the first word."""
+    toks = cmd.split(" ")
+    pre = ""
+    if toks[0] == "sudo" and len(toks) > 1:
+        pre, toks = "sudo ", toks[1:]
+    return pre, toks[0], toks[1:]
+
+
+def placeholder(cmd):
+    """Gold with names swapped for path/to/...; None if nothing to swap."""
+    pre, tool, rest = split_tool(cmd)
+    out, hit = [], False
+    for t in rest:
+        if t.startswith("-") or "://" in t or HOST_TOK.search(t):
+            out.append(t)
+        elif t.endswith("/") or (tool in DIR_TOOLS and t[0].isalnum()):
+            out.append("path/to/directory")
+            hit = True
+        elif FILE_TOK.match(t):
+            out.append("path/to/file")
+            hit = True
+        else:
+            out.append(t)
+    return f"{pre}{tool} {' '.join(out)}".rstrip() if hit else None
+
+
+def tool_swap(cmd, rng):
+    """Gold with its tool replaced by an obscure pool tool; None if no tool."""
+    pre, tool, rest = split_tool(cmd)
+    if not tool[0].isalpha():   # <Ctrl x>, <Esc>:q<Enter>, `.`, `~`
+        return None
+    swap = KNOWN_SWAP.get(tool) or rng.choice(OBSCURE)
+    return " ".join([swap] + rest)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--probe", default="out/probe_qwen-v5.jsonl")
+    ap.add_argument("--basics", default="../dataset/basics.txt")
+    ap.add_argument("--pool", default="../dataset/out/pool_v5.jsonl")
+    ap.add_argument("--out", default="out/dpo_pairs.jsonl")
+    args = ap.parse_args()
+    os.chdir(HERE)
+
+    pool_tools = {split_tool(json.loads(l)["cmd"])[1]
+                  for l in open(args.pool, encoding="utf-8")}
+    missing = [t for t in OBSCURE if t not in pool_tools]
+    assert not missing, f"not in {args.pool}: {missing}"
+
+    pairs = []
+    for r in map(json.loads, open(args.probe, encoding="utf-8")):
+        if r["task"] not in GOLD:      # holdout / homograph: no gold, stays clean
+            continue
+        gold = GOLD[r["task"]]
+        if r["got"] == gold:
+            continue
+        if not r["ok"]:
+            kind = "probe-wrong"
+        elif "path/to" in r["got"]:
+            kind = "probe-placeholder"
+        else:
+            continue
+        pairs.append({"prompt": r["prompt"], "chosen": gold,
+                      "rejected": r["got"], "kind": kind})
+
+    rng = random.Random(42)
+    for cmd, regs in parse_basics(args.basics):
+        rej = {"synth-placeholder": placeholder(cmd),
+               "synth-tool-swap": tool_swap(cmd, rng)}
+        for kind, bad in rej.items():
+            if bad and bad != cmd:
+                for nl in (p for ps in regs.values() for p in ps):
+                    pairs.append({"prompt": nl, "chosen": cmd,
+                                  "rejected": bad, "kind": kind})
+
+    # ALFA stays clean: no pair prompt is an eval prompt.
+    alfa = set()
+    for name in ("eval_bm_300.jsonl", "eval_rojak_300.jsonl"):
+        alfa |= {json.loads(l)["nl"].lower()
+                 for l in open(f"../dataset/{name}", encoding="utf-8")}
+    with open("../dataset/raw/nl2sh_test.csv", newline="", encoding="utf-8") as f:
+        alfa |= {r["nl"].lower() for r in csv.DictReader(f)}
+    leaked = sorted({p["prompt"] for p in pairs if p["prompt"].lower() in alfa})
+    pairs = [p for p in pairs if p["prompt"].lower() not in alfa]
+    print(f"dropped {len(leaked)} prompts that are ALFA eval prompts: {leaked}")
+
+    seen, uniq = set(), []
+    for p in pairs:
+        k = (p["prompt"], p["chosen"], p["rejected"])
+        if k not in seen:
+            seen.add(k)
+            uniq.append(p)
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        for p in uniq:
+            f.write(json.dumps(p, ensure_ascii=False) + "\n")
+    by = collections.Counter(p["kind"] for p in uniq)
+    print(f"{len(uniq)} pairs -> {args.out}")
+    for k, v in sorted(by.items()):
+        print(f"  {k:18s} {v}")
+
+
+def _selfcheck():
+    rng = random.Random(0)
+    assert placeholder("touch notes.txt") == "touch path/to/file"
+    assert placeholder("mkdir newfolder") == "mkdir path/to/directory"
+    assert placeholder("cp notes.txt Documents/") == "cp path/to/file path/to/directory"
+    assert placeholder("wget https://example.com/file.zip") is None
+    assert placeholder("ls -la") is None
+    assert placeholder("ping -c 1 192.168.1.10") is None
+    assert placeholder("curl ifconfig.me") is None
+    assert placeholder("sudo useradd -m ali") is None
+    assert tool_swap("touch newfile.txt", rng) == "fossil add newfile.txt"
+    assert tool_swap("sudo useradd -m newuser", rng) == "kcadm.sh create users -m newuser"
+    assert tool_swap("<Ctrl x>", rng) is None
+    assert split_tool("sudo apt install git") == ("sudo ", "apt", ["install", "git"])
+
+
+if __name__ == "__main__":
+    _selfcheck()
+    main()

--- a/training/rebuild.sh
+++ b/training/rebuild.sh
@@ -5,8 +5,14 @@
 #
 # One variable per run, seed 42 (train.py). Third arg picks the train.py base
 # (default qwen, the incumbent), fourth the seed (issue #57: repeat a run
-# under seeds 43/44 to measure the noise floor). Read RESULTS.md before starting one:
-# the hypothesis goes there first, as something that could come back false.
+# under seeds 43/44 to measure the noise floor). Third arg `dpo` runs dpo.py
+# instead with the second arg as the pairs file (issue #56):
+#
+#   setsid nohup ./rebuild.sh qwen-v5-dpo out/dpo_pairs.jsonl dpo > out/rebuild-qwen-v5-dpo.log 2>&1 &
+#   DPO_BASE=out/X-lora-merged ./rebuild.sh X-dpo out/dpo_pairs.jsonl dpo   # on top of another SFT run
+#
+# Read RESULTS.md before starting one: the hypothesis goes there first, as
+# something that could come back false.
 set -euo pipefail
 cd "$(dirname "$0")"
 export PATH="$HOME/.local/bin:$PATH"
@@ -17,8 +23,12 @@ SEED=${4:-42}
 rm -f "out/REBUILD_DONE_$NAME"
 status() { echo "rebuild[$NAME]: $*"; }
 
-status "train (1 epoch, seed $SEED, $(wc -l <"$POOL") rows)"
-uv run train.py --base "$BASE" --seed "$SEED" --epochs 1 --data "$POOL" --out "out/$NAME-lora" || { echo "DONE rebuild:train-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }
+status "train (1 epoch, seed $SEED, $(wc -l <"$POOL") rows, base $BASE)"
+if [ "$BASE" = dpo ]; then
+  uv run dpo.py --base-ckpt "${DPO_BASE:-out/qwen-v5-lora-merged}" --data "$POOL" --out "out/$NAME-lora"
+else
+  uv run train.py --base "$BASE" --seed "$SEED" --epochs 1 --data "$POOL" --out "out/$NAME-lora"
+fi || { echo "DONE rebuild:train-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }
 
 status "convert + quantize + generate en/bm answers"
 ./finish.sh "out/$NAME-lora-merged" "$NAME" || { echo "DONE rebuild:convert-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }


### PR DESCRIPTION
Part of #56. Stacked on #54's PR.

`training/dpo_pairs.py` (3,455 pairs: 40 real probe misses + synthetic placeholder / tool-swap rejects, ALFA held out), `training/dpo.py` (TRL DPOTrainer, LoRA on a merged SFT checkpoint, β 0.1, 1 epoch, seed 42), `rebuild.sh … dpo` mode with `DPO_BASE`.

Arm A, on run 7: BM +0.010, rojak +0.020, EN −0.013, all p ≥ 0.36; probe placeholders 29 → 23. Hypothesis (placeholder rate < 0.03) falsified.

Arm B, on run 9's checkpoint: flat vs run 9 (BM −0.017, rojak 0, EN −0.020), vs run 7 +0.010 / +0.027 / 0.000. Probe 199 → 205 / 222, placeholders 6 → 2, `git obliterate` and `pm2` flip back to `rm` / `ps aux`, `chmod` ×2 lost to `icacls`.

DPO patches the misses it is handed; 3 min of preference tuning does not move a prior set by 345k SFT rows. Neither arm ships on ALFA. Whether v7-dpo ships on probe grounds is a separate decision — see the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
