### PR TITLE
Retrieval over tldr in the prompt does not fit constraint 3, closes as measured (#55)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1095,3 +1095,64 @@ distractor, not a no-op. Falsified if holdout does not move or basics
 drops; then retrieval needs a multilingual embedder (`multilingual-e5-small`
 Q8 is ~120 MB, over the issue's cap) or a retrained model that has seen
 `Examples:` in training, both out of scope here.
+
+### Result: falsified, retrieval on halves the probe
+
+`probe.py --retrieve 1`, run 7 GGUF, same 223 prompts, `training/out/probe_qwen-v5_ret1.jsonl`;
+the off column is `probe_qwen-v5.jsonl` rescored with today's regexes so both
+columns share them.
+
+| | retrieval off (run 7) | retrieval on, top-1 | n |
+|---|---|---|---|
+| basics tasks (unseen phrasings) | 0.90 | **0.53** | 177 |
+| holdout (tools absent from basics.txt) | 0.90 | **0.30** | 40 |
+| english | 1.00 | 0.57 | 35 |
+| rojak | 0.91 | 0.57 | 35 |
+| colloquial | 0.84 | 0.35 | 31 |
+| formal | 0.83 | 0.71 | 35 |
+| homograph BM-sense / EN-sense | 1.00 / 0.67 | 0.33 / 0.67 | 3 / 3 |
+
+Paired over all 223 prompts: **lost 93, gained 7** (exact two-sided
+p ≈ 1e-19). Not a small miss; the mechanism does the opposite of the
+hypothesis.
+
+**What the failures look like.** The model treats the retrieved line as the
+answer, not as context: `nak buat fail baru` → `systemctl edit foo.service`,
+`nak tukar default shell ke zsh` → `unshare --shell=ash|bash|dash|ksh|zsh`,
+`tunjuk nilai variable HOME` → `flux var set --home`. When the retrieved
+line is right the answer is right — `empty the file app.log without
+deleting it` → `truncate [-s|--size] 0 app.log` (gained), `run ./slow.sh
+but stop it after 10 seconds` → `timeout 10 ./slow.sh`, `find where git and
+its man page are installed` → `whereis -s gcc -m git`. The seven gains are
+all of that shape and six of them are English or formal BM. So retrieval is
+only as good as the embedder, and an English-only embedder over Malay
+queries is wrong most of the time (`nak buat file baru` → `hexedit`,
+`kioclient`); the model then copies the wrong tool with confidence, and the
+`Examples:` framing also breaks phrasings it answered correctly with no
+context at all — 93 of them.
+
+**Reading.** Two independent problems, either fatal on its own:
+
+1. Cost. Top-3 is 2.1 s warm at the thread count camne gives a 4-core box,
+   on a host faster than the target. RSS is fine (1.8 GB). It is prompt
+   evaluation of ~70 uncacheable tokens per query on a 1.5B model at
+   ~70 tok/s. Nothing in the retrieval design changes that except fewer
+   tokens, and top-1 is already the floor.
+2. Accuracy. The run 7 model has never seen `Examples:` in a user turn and
+   copies whatever is there. That is fixable only by the thing the issue
+   puts out of scope — training rows with retrieved context — and only
+   worth attempting with an embedder that reads Malay, which is over the
+   100 MB cap (`multilingual-e5-small` Q8 ≈ 120 MB, f16 ≈ 230 MB).
+
+**Not running ALFA**: the probe result is a 40-point drop on the block the
+issue cares about, and ALFA generation is CPU-only while the GPU is busy
+(900 prompts × ~1.5 s ≈ 25 min per register per arm; feasible, pointless
+here). Command, if someone wants the number anyway, is the run 7 recipe with
+`probe.py --retrieve 1`'s prefix applied in `eval_gen.py`; that flag does not
+exist in `eval_gen.py` and is not being added for a result this clear.
+
+**Decision: closes #55 as measured.** Nothing ships. `retrieve.py`,
+`bench_retrieval.py` and `probe.py --retrieve K` stay so the next attempt
+(multilingual embedder + retrieval-aware training rows, if ever) starts
+from the measurement instead of the idea. Index file (`out/tldr_index.npz`)
+and the bge GGUF are build artifacts, not committed.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1113,7 +1113,7 @@ columns share them.
 | homograph BM-sense / EN-sense | 1.00 / 0.67 | 0.33 / 0.67 | 3 / 3 |
 
 Paired over all 223 prompts: **lost 93, gained 7** (exact two-sided
-p ≈ 1e-19). Not a small miss; the mechanism does the opposite of the
+p ≈ 3e-20). Not a small miss; the mechanism does the opposite of the
 hypothesis.
 
 **What the failures look like.** The model treats the retrieved line as the

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1032,3 +1032,66 @@ is inside run 7's CI on every register and −0.02 EN on its own base.
 Next, if this thread continues: weight the real-mistake pairs (1.2% of the
 set today), or grow the head of the pool for the beginner verbs (#54's
 note) and DPO on top of that — the pool sets the prior, DPO trims it.
+
+
+## Retrieval over tldr in the prompt (issue #55)
+
+The issue says the cost measurement decides, so it comes first. Everything
+below is the pinned CPU build (`b10333`), `-ngl 0`, run 7 GGUF
+(`qwen-v5-Q4_K_M`), same decoding as `bench.py`, `training/bench_retrieval.py`.
+The GPU was busy with a training job while this ran, so absolute numbers
+carry that noise; the baseline row reproduces run 7's bench within it.
+
+**Embedding model.** `bge-small-en-v1.5` f16 GGUF, 67 MB on disk (the
+`bge-small / e5-small / arctic-xs` class the issue names; English-only, which
+matters below). Served by the same pinned `llama-server` with `--embeddings
+--pooling cls -c 512`: 0.2 s to load, **101 MB RSS**, **6–9 ms** per query
+embed at 2–4 threads. The embedder is not the cost.
+
+**Index.** `dataset/raw/tldr.csv` deduped on (description, command): 29,153
+lines, description embedded, line shape `description: command`. Vectors
+29,153 × 384 f16 = **22 MB** (the `.npz` with the text is 70 MB); building
+it is 4 min of CPU at 4 threads. Query → top-3 is 16–21 ms end to end.
+
+**Cost, both servers resident, 12 queries, median.** Three (or one)
+*distinct* tldr lines per query — a fixed set is not a measurement: the
+pinned server keeps evicted prompts in RAM and served a rotated fixed set
+from cache at 13 prompt tokens instead of 80.
+
+| threads | prompt | prompt tokens evaluated | warm s (max) | tok/s | combined RSS MB |
+|---|---|---|---|---|---|
+| 2 | baseline | 12 | 0.73–0.77 (1.4–1.7) | 26–27 | 1768 |
+| 2 | + top-3 `Examples:` | 80 | **2.06–2.18 (3.1)** | 26–28 | 1817 |
+| 2 | + top-1 | 31 | 1.10 (1.6) | 28 | 1821 |
+| 4 | baseline | 12 | 0.43–0.53 (0.8–1.3) | 30–42 | 1768 |
+| 4 | + top-3 `Examples:` | 80 | **1.30–1.31 (1.8)** | 38–41 | 1813 |
+| 4 | + top-1 | 31 | 0.61 (1.0) | 42 | 1816 |
+
+Two runs, both shown where they differ. RSS is not the problem: 1.8 GB
+combined, 0.7 GB under the ceiling. Prompt evaluation is: the tuned 1.5B
+processes prompt tokens at ~60–80 tok/s on 2 threads, so 68 extra tokens
+per query is 1.3 s before the first output token, every query, because the
+retrieved lines differ per query and defeat `cache_prompt`.
+
+**Verdict vs constraint 3.** `engine.go` gives a 4-core box 2 threads. At 2
+threads top-3 retrieval is **2.1 s median, 3.1 s worst**, over the 1.5 s
+warm budget on a host that is already faster than the target box. At 4
+threads it is 1.3 s median with a 1.8 s tail: under the median budget here,
+over it on the target. **Top-3 as the issue specifies does not fit.** Top-1
+fits (1.1 s at 2 threads, 0.6 s at 4), with less headroom than baseline and
+one line of context instead of three, so it is measured below rather than
+assumed useless.
+
+**Hypothesis, written before the probe run.** With top-1 retrieval on, the
+run 7 model will gain on the probe's holdout block (tools absent from
+basics.txt: `truncate`, `tac`, `tee`, `timeout`, `chsh`, `printenv`, `nl`)
+by ≥ +0.05, because for those tasks the right tldr line is the answer, and
+hold basics tasks within 0.02, because those the model already knows. Two
+things say the gain will be smaller than the idea promises: the embedder is
+English-only, so Malay phrasings that carry no English technical noun
+retrieve wrong lines (`nak buat file baru` → `hexedit`, `kioclient`;
+spot-checked before the run), and a bad line in front of a 1.5B model is a
+distractor, not a no-op. Falsified if holdout does not move or basics
+drops; then retrieval needs a multilingual embedder (`multilingual-e5-small`
+Q8 is ~120 MB, over the issue's cap) or a retrained model that has seen
+`Examples:` in training, both out of scope here.

--- a/training/bench_retrieval.py
+++ b/training/bench_retrieval.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Constraint-3 cost of retrieval (issue #55): an embedding server resident
+next to the generator, and three `Examples:` lines prepended to the user turn.
+
+  python3 bench_retrieval.py out/qwen-v5-Q4_K_M.gguf out/bge-small-en-v1.5-f16.gguf
+
+CPU only, pinned llama-server, 4 threads (what ships). Reports embed latency
+and RSS of the embedding server, then the generator's warm latency / tok/s /
+RSS with the baseline prompt and with the retrieval prompt, both servers up.
+Same decoding as bench.py. Combined RSS is what constraint 3 gates.
+"""
+import argparse
+import json
+import os
+import re
+import signal
+import statistics
+import subprocess
+import sys
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench import QUERIES, SYSTEM, rss_mb  # noqa: E402
+
+PINNED = os.path.expanduser("~/.cache/camne/bin/llama-b10333/llama-server")
+GEN_PORT, EMB_PORT = 18097, 18098
+
+# Three tldr one-liners in the shape retrieve.py will produce; ~150 tokens
+# is the budget the issue names, so pad to that shape rather than the
+# shortest lines in the pool.
+TLDR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "dataset", "raw", "tldr.csv")
+
+
+def examples(i, k=3):
+    """Real retrieval returns different lines per query, so the prompt cache
+    covers the system turn only. Rotating one fixed set is not enough: the
+    pinned server keeps several evicted prompts in RAM and served the third
+    ordering from cache (prompt_n 13, not ~90). Three distinct tldr lines per
+    query, 36 in all, no two queries share one."""
+    import csv
+    rows = [r for r in csv.DictReader(open(TLDR, encoding="utf-8"))
+            if 60 <= len(r["nl"]) + len(r["bash"]) <= 110][100:136]
+    lines = [f"{r['nl']}: {r['bash']}" for r in rows[3 * i:3 * i + k]]
+    return "Examples:\n" + "\n".join(lines) + "\nRequest: "
+
+
+def wait(port):
+    t0 = time.monotonic()
+    while True:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=2)
+            return time.monotonic() - t0
+        except Exception:
+            if time.monotonic() - t0 > 300:
+                raise RuntimeError("server never became ready")
+            time.sleep(0.2)
+
+
+def post(port, path, body, timeout=600):
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+
+def ask(q, i=0, k=0):
+    prefix = examples(i, k) if k else ""
+    prompt = (f"<|im_start|>system\n{SYSTEM}<|im_end|>\n"
+              f"<|im_start|>user\n{prefix}{q}<|im_end|>\n<|im_start|>assistant\n")
+    t0 = time.monotonic()
+    d = post(GEN_PORT, "/completion", {
+        "prompt": prompt, "n_predict": 64, "temperature": 0,
+        "grammar": "root ::= [ -~]+", "stop": ["\n"],
+        "repeat_penalty": 1.08, "repeat_last_n": 64, "cache_prompt": True})
+    tm = d.get("timings", {})
+    return time.monotonic() - t0, tm.get("predicted_per_second", 0), tm.get("prompt_n", 0)
+
+
+def embed(q):
+    t0 = time.monotonic()
+    post(EMB_PORT, "/v1/embeddings", {"input": q}, timeout=60)
+    return time.monotonic() - t0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("gen")
+    ap.add_argument("emb")
+    ap.add_argument("--server", default=PINNED)
+    ap.add_argument("--threads", default="2,4")
+    a = ap.parse_args()
+    res = [run(a, int(t)) for t in a.threads.split(",")]
+    with open("out/bench_retrieval.json", "w") as f:
+        json.dump(res, f, indent=1)
+
+
+def run(a, threads):
+    a.threads = threads
+    common = ["-t", str(a.threads), "-ngl", "0", "--no-webui"]
+    emb = subprocess.Popen([a.server, "-m", a.emb, "--embeddings", "--pooling", "cls",
+                            "-c", "512", "-b", "512", "-ub", "512", "--port", str(EMB_PORT)] + common,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    gen = subprocess.Popen([a.server, "-m", a.gen, "-c", "2048", "--port", str(GEN_PORT)] + common,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        emb_load = wait(EMB_PORT)
+        gen_load = wait(GEN_PORT)
+        embed(QUERIES[0])
+        emb_lat = statistics.median(embed(q) for q in QUERIES)
+        emb_rss = rss_mb(emb.pid)
+        out = {"emb_model": os.path.basename(a.emb), "emb_mb": round(os.path.getsize(a.emb) / 1e6),
+               "emb_load_s": round(emb_load, 2), "gen_load_s": round(gen_load, 2),
+               "emb_ms": round(emb_lat * 1000, 1), "emb_rss_mb": round(emb_rss), "threads": a.threads}
+        for name, k in (("baseline", 0), ("retrieval", 3), ("retrieval_top1", 1)):
+            ask(QUERIES[0], 0, k)  # warm the cache
+            lat, tps, pn = zip(*(ask(q, i, k) for i, q in enumerate(QUERIES)))
+            out[name] = {"warm_s": round(statistics.median(lat), 3),
+                         "warm_max_s": round(max(lat), 3),
+                         "tok_s": round(statistics.median(tps), 1),
+                         "prompt_tokens": int(statistics.median(pn)),
+                         "gen_rss_mb": round(rss_mb(gen.pid)),
+                         "combined_rss_mb": round(rss_mb(gen.pid) + emb_rss)}
+        # end-to-end warm: embed + generate with the longer prompt
+        for name in ("retrieval", "retrieval_top1"):
+            out[name]["warm_e2e_s"] = round(out[name]["warm_s"] + emb_lat, 3)
+        print(json.dumps(out, indent=1))
+        return out
+    finally:
+        for p in (emb, gen):
+            p.send_signal(signal.SIGTERM)
+            p.wait(timeout=30)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/probe.py
+++ b/training/probe.py
@@ -546,7 +546,13 @@ HOMOGRAPH = [
 ]
 
 
+RETRIEVE = 0  # --retrieve K: prepend K tldr lines (retrieve.py) to the user turn
+
+
 def chatml(q):
+    if RETRIEVE:
+        import retrieve
+        q = retrieve.prefix(q, RETRIEVE) + q
     return (f"<|im_start|>system\n{SYSTEM}<|im_end|>\n"
             f"<|im_start|>user\n{q}<|im_end|>\n<|im_start|>assistant\n")
 
@@ -584,6 +590,8 @@ def main():
     ap.add_argument("--server", default=PINNED if os.path.exists(PINNED) else "llama-server")
     ap.add_argument("--threads", type=int, default=4)
     ap.add_argument("--out", default="out/probe.jsonl")
+    ap.add_argument("--retrieve", type=int, default=0, metavar="K",
+                    help="prepend top-K tldr lines to the user turn (issue #55)")
     ap.add_argument("--rescore", metavar="JSONL",
                     help="re-apply the current regexes to a saved run; no server")
     args = ap.parse_args()
@@ -614,6 +622,12 @@ def main():
         return
 
     proc = boot(args.server, args.model, args.threads)
+    global RETRIEVE
+    RETRIEVE = args.retrieve
+    emb = None
+    if RETRIEVE:
+        import retrieve
+        emb = retrieve.serve()
     rows = []
     try:
         for t in TASKS:
@@ -633,6 +647,8 @@ def main():
     finally:
         proc.send_signal(signal.SIGTERM)
         proc.wait(timeout=30)
+        if emb:
+            emb.terminate()
 
     os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
     with open(args.out, "w") as f:

--- a/training/retrieve.py
+++ b/training/retrieve.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Cosine top-k over tldr one-liners (issue #55).
+
+  python3 retrieve.py                        # builds out/tldr_index.npz if missing
+  python3 retrieve.py "nak convert heic ke jpg"
+
+Index: dataset/raw/tldr.csv (nl, bash), deduped, description embedded with
+the bge-small GGUF served by the pinned llama-server on EMB_PORT. Lines are
+`description: command`, the shape prepended to the user turn as `Examples:`.
+"""
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TLDR = os.path.join(HERE, "..", "dataset", "raw", "tldr.csv")
+INDEX = os.path.join(HERE, "out", "tldr_index.npz")
+EMB_MODEL = os.path.join(HERE, "out", "bge-small-en-v1.5-f16.gguf")
+PINNED = os.path.expanduser("~/.cache/camne/bin/llama-b10333/llama-server")
+EMB_PORT = 18098
+
+
+def serve():
+    """Start the embedding server if nothing answers on EMB_PORT."""
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{EMB_PORT}/health", timeout=1)
+        return None
+    except Exception:
+        pass
+    p = subprocess.Popen([PINNED, "-m", EMB_MODEL, "--embeddings", "--pooling", "cls",
+                          "-c", "512", "-b", "512", "-ub", "512", "-t", "4", "-ngl", "0",
+                          "--no-webui", "--port", str(EMB_PORT)],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    t0 = time.monotonic()
+    while True:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{EMB_PORT}/health", timeout=1)
+            return p
+        except Exception:
+            if time.monotonic() - t0 > 60:
+                raise RuntimeError("embedding server never became ready")
+            time.sleep(0.2)
+
+
+def embed(texts):
+    req = urllib.request.Request(f"http://127.0.0.1:{EMB_PORT}/v1/embeddings",
+                                 data=json.dumps({"input": texts}).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=600) as r:
+        d = json.load(r)["data"]
+    v = np.array([e["embedding"] for e in sorted(d, key=lambda e: e["index"])], dtype=np.float32)
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+def build():
+    seen, lines, descs = set(), [], []
+    for r in csv.DictReader(open(TLDR, encoding="utf-8")):
+        key = (r["nl"], r["bash"])
+        if key in seen or not r["nl"] or not r["bash"]:
+            continue
+        seen.add(key)
+        lines.append(f"{r['nl']}: {r['bash']}")
+        descs.append(r["nl"])
+    vecs = np.concatenate([embed(descs[i:i + 256]) for i in range(0, len(descs), 256)])
+    np.savez(INDEX, vecs=vecs.astype(np.float16), lines=np.array(lines))
+    return vecs, lines
+
+
+_IDX = None
+
+
+def load():
+    global _IDX
+    if _IDX is None:
+        if not os.path.exists(INDEX):
+            build()
+        z = np.load(INDEX)
+        _IDX = (z["vecs"].astype(np.float32), list(z["lines"]))
+    return _IDX
+
+
+def top(query, k=3):
+    vecs, lines = load()
+    q = embed([query])[0]
+    best = np.argsort(vecs @ q)[::-1][:k]
+    return [lines[i] for i in best]
+
+
+def prefix(query, k=3):
+    return "Examples:\n" + "\n".join(top(query, k)) + "\nRequest: "
+
+
+if __name__ == "__main__":
+    p = serve()
+    try:
+        t0 = time.monotonic()
+        vecs, lines = load()
+        print(f"{len(lines)} lines, {os.path.getsize(INDEX) / 1e6:.1f} MB index, "
+              f"loaded in {time.monotonic() - t0:.1f}s")
+        for q in sys.argv[1:] or ["nak convert heic ke jpg", "nak tengok certificate expiry",
+                                  "convert heic to jpg", "check ssl certificate expiry",
+                                  "nak buat file baru", "empty the file app.log without deleting it"]:
+            t0 = time.monotonic()
+            hits = top(q)
+            print(f"\n{q}  ({(time.monotonic() - t0) * 1000:.0f} ms)")
+            for h in hits:
+                print("  " + h)
+    finally:
+        if p:
+            p.terminate()


### PR DESCRIPTION
Closes #55. Stacked on #56's PR.

bge-small-en-v1.5 f16 (67 MB) served by the pinned llama-server `--embeddings`: 6–9 ms per query, RSS 101 MB, combined RSS 1.8 GB — fine. Latency is not: ~70 uncacheable prompt tokens per query. Top-3 = 2.06–2.18 s warm at 2 threads, 1.30 s (1.8 s tail) at 4. Top-1 fits, so it was measured: probe basics 0.90 → 0.53, holdout 0.90 → 0.30 (p ≈ 3e-20) — an English-only embedder on Malay queries retrieves the wrong tool and the model copies it.

Kept: `training/bench_retrieval.py`, `training/retrieve.py`, `probe.py --retrieve K`, RESULTS.md section. Nothing ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
