### PR TITLE
Runs 9, DPO arms and the retrieval measurement (#54, #56, #55)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -907,3 +907,73 @@ pool change should add head rows for the beginner verbs (`rm`, `ps`,
 `nano`) rather than cut more tail — and #56's DPO pairs already encode
 exactly the `git obliterate`/`pm2` class of miss, so DPO on this
 checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`) is the cheap next arm.
+
+
+## Run qwen-v5-dpo: DPO on the model's own mistakes (issue #56)
+
+**Hypothesis, written before the run.** Every SFT run so far has taught the
+model what to say and nothing about what not to say. Run 7's remaining
+misses are not coverage holes, they are near-misses on the same tokens the
+pool teaches: `touch path/to/file1 path/to/file2 ...` (right tool, tldr
+placeholder — 50,878 of the 345,636 pool rows carry `path/to`), and a
+same-pool obscure tool where the pool has a common one (`fossil add`,
+`skicka mkdir`, `kcadm.sh create users`, `lzop`, `gdu`, `fkill`, `smem`).
+Run 8 tried to fix these by adding rows and moved BM by −0.06 instead. A
+DPO stage that holds the gold as chosen and those exact outputs as rejected
+pushes against the failure directly, without adding rows to the SFT pool or
+changing its order. Prediction: on the shipped CPU path the placeholder
+rate on the probe's 177 basics-task prompts falls from **24/177 (0.14)** to
+under 0.03, `nak buat file baru` returns `touch newfile.txt` (or any
+`touch` with a real name), `nak buat user baru` returns `useradd`, and the
+three ALFA registers stay inside their run 7 CIs (BM 0.487, rojak 0.490,
+EN 0.543). Falsified if any ALFA register drops with p < 0.05 — then the
+preference stage is trading beginner exactness for one-liner accuracy and
+β or the pair mix is next — or if the placeholder rate does not move, which
+would mean 3,455 pairs at β = 0.1 do not shift a preference that 15% of the
+pool voted for.
+
+One variable vs run 7: the DPO stage. `training/dpo.py` puts a fresh
+r32/a64 LoRA on the run 7 merged checkpoint (`out/qwen-v5-lora-merged`),
+TRL `DPOTrainer`, sigmoid loss, β = 0.1, 1 epoch, seed 42, effective batch
+32, lr 5e-6 (Unsloth's DPO reference recipe; SFT's 2e-4 would wreck the
+policy), reference = the same weights with the adapter disabled. Prompt
+text is train.py's literal ChatML. Same GGUF path as every run
+(`finish.sh` → f16 → Q4_K_M), same pinned CPU probe. `trl` 0.24.0 was
+already in `uv.lock` (unsloth pulls it); nothing was added.
+
+**Pairs, `training/dpo_pairs.py` → `out/dpo_pairs.jsonl`, 3,455 total:**
+
+| kind | n | chosen | rejected |
+|---|---|---|---|
+| probe-wrong | 18 | basics.txt command for the probe task | run 7's actual output (`gdu --disk-usage`, `fkill :8080`, `kcadm.sh create users ...`, `jobs`, `smem --memstats`, `tempdir -c` ...) |
+| probe-placeholder | 22 | same | run 7's tool-level pass that was a placeholder (`touch path/to/file1 path/to/file2 ...`, `skicka mkdir path/to/folder`, `rm path/to/file1 ...`, `chmod 644 /path/to/file`) |
+| synth-placeholder | 999 | basics.txt gold, every phrasing | gold with names swapped for `path/to/file` / `path/to/directory` |
+| synth-tool-swap | 2,416 | basics.txt gold, every phrasing | gold's tool swapped for what run 7 reached for (`touch`→`fossil add`, `mkdir`→`skicka mkdir`, `useradd`→`kcadm.sh create users`, `tar`→`lzop`, `df`→`gdu`, `kill`→`fkill`, `free`→`smem`) or a low-count pool tool drawn with seed 42 |
+
+Unweighted: the 40 real-mistake pairs are 1.2% of the set. If the probe
+misses persist while the synthetic kinds land, weighting the real pairs is
+the next variable, not a bigger β.
+
+**Split, stated.** ALFA is not touched: no pair is built from any ALFA
+task, and the three basics.txt English phrasings that are verbatim
+nl2sh_test prompts (`print hello world`, `print the current user`, `list
+all users on the system`) are dropped from the pair set. The probe main
+block is **not** clean after this run: the 40 probe-* pairs train on the
+probe's own prompts, so post-DPO basics-task numbers measure recall of the
+fix, not phrasing generalisation; read them as "did the specific miss go
+away", and read the ALFA and HOLDOUT columns for generalisation. HOLDOUT
+(no basics.txt command to serve as chosen) and the homograph guard get no
+pairs and stay clean. Homograph EN-sense (`fails` = failure) is the
+regression to watch: `nak buat fail baru` → `touch` is now a chosen row.
+
+Measured before the run (run 7, shipped model, pinned CPU build): probe
+basics 0.90 / holdout 0.78 / homograph 1.00 / 0.67, placeholder rate 24/177
+on basics prompts and 25/223 overall, ALFA BM 0.487 / rojak 0.490 / EN
+0.543, bench 4 threads 36.8 tok/s / 0.57 s warm / 1.38 s cold / 1626 MB.
+#47 prompts exact: see the run 8 table above (run 7 column).
+
+Order: queued behind #54's retrain. If #54 ships, `DPO_BASE=out/<54
+merged>` puts this stage on top of it and the comparison row becomes #54's
+run instead of run 7; the pairs are rebuilt from that run's probe file
+(`dpo_pairs.py --probe out/probe_<54>.jsonl`). Not started; hypothesis
+written first.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -822,7 +822,7 @@ out/pool_v7.jsonl`, seed 42, deterministic):**
    list plus every tool basics.txt teaches, plus shell keywords `for`,
    `while`, `if`, `until`, `case`, which are composition, not tools).
    Sampled by whole pair so the four registers of a command stay together.
-   15,754 rows dropped from 61 tools (`az`, `aws`, `kubectl`, `cargo`,
+   15,754 rows dropped from 51 tools (`az`, `aws`, `kubectl`, `cargo`,
    `gh`, `tlmgr`, `pio`, `shuf`, … each 1,200 → 300).
 3. `find` to 5% of the final pool. It is core and genuinely common, but at
    17% it is the answer the model reaches for when unsure; 5% still leaves

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1095,3 +1095,64 @@ distractor, not a no-op. Falsified if holdout does not move or basics
 drops; then retrieval needs a multilingual embedder (`multilingual-e5-small`
 Q8 is ~120 MB, over the issue's cap) or a retrained model that has seen
 `Examples:` in training, both out of scope here.
+
+### Result: falsified, retrieval on halves the probe
+
+`probe.py --retrieve 1`, run 7 GGUF, same 223 prompts, `training/out/probe_qwen-v5_ret1.jsonl`;
+the off column is `probe_qwen-v5.jsonl` rescored with today's regexes so both
+columns share them.
+
+| | retrieval off (run 7) | retrieval on, top-1 | n |
+|---|---|---|---|
+| basics tasks (unseen phrasings) | 0.90 | **0.53** | 177 |
+| holdout (tools absent from basics.txt) | 0.90 | **0.30** | 40 |
+| english | 1.00 | 0.57 | 35 |
+| rojak | 0.91 | 0.57 | 35 |
+| colloquial | 0.84 | 0.35 | 31 |
+| formal | 0.83 | 0.71 | 35 |
+| homograph BM-sense / EN-sense | 1.00 / 0.67 | 0.33 / 0.67 | 3 / 3 |
+
+Paired over all 223 prompts: **lost 93, gained 7** (exact two-sided
+p ≈ 1e-19). Not a small miss; the mechanism does the opposite of the
+hypothesis.
+
+**What the failures look like.** The model treats the retrieved line as the
+answer, not as context: `nak buat fail baru` → `systemctl edit foo.service`,
+`nak tukar default shell ke zsh` → `unshare --shell=ash|bash|dash|ksh|zsh`,
+`tunjuk nilai variable HOME` → `flux var set --home`. When the retrieved
+line is right the answer is right — `empty the file app.log without
+deleting it` → `truncate [-s|--size] 0 app.log` (gained), `run ./slow.sh
+but stop it after 10 seconds` → `timeout 10 ./slow.sh`, `find where git and
+its man page are installed` → `whereis -s gcc -m git`. The seven gains are
+all of that shape and six of them are English or formal BM. So retrieval is
+only as good as the embedder, and an English-only embedder over Malay
+queries is wrong most of the time (`nak buat file baru` → `hexedit`,
+`kioclient`); the model then copies the wrong tool with confidence, and the
+`Examples:` framing also breaks phrasings it answered correctly with no
+context at all — 93 of them.
+
+**Reading.** Two independent problems, either fatal on its own:
+
+1. Cost. Top-3 is 2.1 s warm at the thread count camne gives a 4-core box,
+   on a host faster than the target. RSS is fine (1.8 GB). It is prompt
+   evaluation of ~70 uncacheable tokens per query on a 1.5B model at
+   ~70 tok/s. Nothing in the retrieval design changes that except fewer
+   tokens, and top-1 is already the floor.
+2. Accuracy. The run 7 model has never seen `Examples:` in a user turn and
+   copies whatever is there. That is fixable only by the thing the issue
+   puts out of scope — training rows with retrieved context — and only
+   worth attempting with an embedder that reads Malay, which is over the
+   100 MB cap (`multilingual-e5-small` Q8 ≈ 120 MB, f16 ≈ 230 MB).
+
+**Not running ALFA**: the probe result is a 40-point drop on the block the
+issue cares about, and ALFA generation is CPU-only while the GPU is busy
+(900 prompts × ~1.5 s ≈ 25 min per register per arm; feasible, pointless
+here). Command, if someone wants the number anyway, is the run 7 recipe with
+`probe.py --retrieve 1`'s prefix applied in `eval_gen.py`; that flag does not
+exist in `eval_gen.py` and is not being added for a result this clear.
+
+**Decision: closes #55 as measured.** Nothing ships. `retrieve.py`,
+`bench_retrieval.py` and `probe.py --retrieve K` stay so the next attempt
+(multilingual embedder + retrieval-aware training rows, if ever) starts
+from the measurement instead of the idea. Index file (`out/tldr_index.npz`)
+and the bge GGUF are build artifacts, not committed.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1113,7 +1113,7 @@ columns share them.
 | homograph BM-sense / EN-sense | 1.00 / 0.67 | 0.33 / 0.67 | 3 / 3 |
 
 Paired over all 223 prompts: **lost 93, gained 7** (exact two-sided
-p ≈ 1e-19). Not a small miss; the mechanism does the opposite of the
+p ≈ 3e-20). Not a small miss; the mechanism does the opposite of the
 hypothesis.
 
 **What the failures look like.** The model treats the retrieved line as the

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -977,3 +977,58 @@ merged>` puts this stage on top of it and the comparison row becomes #54's
 run instead of run 7; the pairs are rebuilt from that run's probe file
 (`dpo_pairs.py --probe out/probe_<54>.jsonl`). Not started; hypothesis
 written first.
+
+**Result (2026-08-17): both DPO arms ran; the hypothesis is falsified on
+run 7 and half-met on the pool_v7 checkpoint.** Each DPO stage is 3 min on
+the 3090 (3,4xx pairs, 1 epoch), reward accuracy 0.99 by the end — the
+pairs are learned; the question was whether that generalises. #57's error
+bar (≤ 0.013 same-recipe) applies.
+
+*Arm A — `qwen-v5-dpo`, on run 7's merged checkpoint, pairs from run 7's
+probe (3,455):*
+
+| register | run 7 | run 7 + DPO | diff | 95% CI | lost / gained | p |
+|---|---|---|---|---|---|---|
+| BM | 0.487 | 0.497 | +0.010 | [−0.023, +0.043] | 11 / 14 | 0.69 |
+| rojak | 0.490 | 0.510 | +0.020 | [−0.016, +0.056] | 12 / 18 | 0.36 |
+| EN | 0.543 | 0.530 | −0.013 | [−0.051, +0.025] | 19 / 15 | 0.61 |
+
+Probe 199 → 205 / 222, holdout 36 → 36. Placeholder answers **29 → 23**:
+`nak buat file baru` is now `touch path/to/file1 path/to/file2 ...`
+instead of `fossil add path/to/file` — the tool moved, the placeholder did
+not, although exactly that string is a rejected row. `create user` 2 → 3
+of 5, `kill process on port` gains ×2 (`fuser -k 8080/tcp`). Falsified:
+the placeholder rate went 0.13 → 0.10, not below 0.03; ALFA is inside
+every CI. Bench 0.65 s warm at 4 threads (was 0.47; retest before reading
+anything into it), 1.49 GB.
+
+*Arm B — `qwen-v7-dpo`, on run 9's checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`),
+pairs rebuilt from run 9's probe (3,430):*
+
+| register | run 9 (v7) | v7 + DPO | diff | 95% CI | p | vs run 7 |
+|---|---|---|---|---|---|---|
+| BM | 0.513 | 0.497 | −0.017 | [−0.054, +0.021] | 0.49 | +0.010, p 0.82 |
+| rojak | 0.517 | 0.517 | 0.000 | [−0.032, +0.032] | 1 | +0.027, p 0.40 |
+| EN | 0.563 | 0.543 | −0.020 | [−0.057, +0.017] | 0.38 | 0.000, p 1 |
+
+Probe 199 → **205** / 222, holdout 33 → 34, placeholders **6 → 2**.
+Run 9's regressions come back: `delete file` 2 → 5 of 6 (`rm filename`,
+`git obliterate` gone on three of four phrasings), `list processes` 0 → 2
+of 4 (`ps aux`, `pm2` gone on two). Lost: `change permission` ×2 →
+`icacls file_or_directory` (Windows tool, tldr row; not in the pair set —
+DPO pushed `chmod` down for reasons the pairs do not name), `change
+shell/rojak`. Bench 0.43 s warm at 4 threads, 1.5 GB.
+
+Reading. DPO on ~40 real mistakes plus 3,400 synthetic pairs does what the
+pairs literally say — the specific `fossil`/`kcadm.sh`/`git obliterate`/
+`pm2` misses it was shown flip back — and nothing further: the placeholder
+habit survives on run 7 (23 answers), ALFA does not move on either base,
+and every gain is offset by a new obscure-tool miss elsewhere (`icacls`).
+Three minutes of preference tuning cannot fix a prior that 345k SFT rows
+set; it can only patch the misses it was handed. Neither arm ships:
+v7-dpo has the best probe (205, 2 placeholders, all #47 targets pass) but
+is inside run 7's CI on every register and −0.02 EN on its own base.
+
+Next, if this thread continues: weight the real-mistake pairs (1.2% of the
+set today), or grow the head of the pool for the beginner verbs (#54's
+note) and DPO on top of that — the pool sets the prior, DPO trims it.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -774,3 +774,99 @@ inside the scorer's own ±5/300. Consequences:
 - Protocol, going into CLAUDE.md § "Model work": one seed suffices when
   the paired CI excludes zero; a delta inside ±0.02 is "no difference",
   never a trend; anything read off a single register at p ≥ 0.05 is noise.
+
+## Run 9: the pool's tool prior (issue #54)
+
+**Hypothesis, written before the run.** Runs 7, 8 and the Qwen3.5-2B arm
+all answer `nak buat file baru` with a tldr placeholder or `fossil add`,
+and run 8 showed that 85 hand rows do not move that. The cause is the
+prior the pool teaches, not a coverage hole: 16% of pool_v6's rows have
+`path/to/...` or `<name>` in the command, `find` alone is 17% of the pool,
+and 4,819 distinct first tokens split the rest, so a prompt that lands
+off-distribution is answered with a placeholder from a tool the model saw
+300 times. Removing the placeholder rows, capping the long tail at 300
+rows per non-core tool and cutting `find` to 5% (`dataset/prior.py`,
+`pool_v7`) will (a) take the placeholder rate on the probe's outputs to
+zero, (b) fix `create file` unnamed (`nak buat file baru`,
+`nak buat satu file baru`, `tolong buat file baru`) with a real filename in
+the answer, and (c) hold ALFA English within run 7's CI. Falsified if the
+probe still emits `path/to` or a long-tail tool for the unnamed prompts —
+then the prior is in the base, not the pool — or if English drops by more
+than the CI, which would mean the 34% of rows removed were carrying
+accuracy (RESULTS.md, run 2, the mistake this cut is closest to
+repeating).
+
+One variable changed from run 7: the pool. `pool_v7 = prior.py(pool_v6)`,
+where `pool_v6 = pool_v4.bal + basics.jsonl` at 330 tasks; the 85 unnamed
+rows from #47 are in, so against run 7 the pool differs by the prior fix
+plus those rows, and against run 8 by the prior fix alone. Same recipe,
+seed 42, 1 epoch. Probe prompts unchanged, none verbatim in basics.txt.
+
+**What prior.py does, in order (`python3 prior.py out/pool_v6.jsonl
+out/pool_v7.jsonl`, seed 42, deterministic):**
+
+1. Placeholders. `path/to/...` and `<name>` in the command. Where every
+   placeholder also appears verbatim in the NL — the user typed the path,
+   `senarai folder kat /path/to/dir` → `find /path/to/dir -type d` — both
+   sides are rewritten to one concrete name (`path/to/dir` → `projek`,
+   `<file>` → `notes.txt`, otherwise the last path component) so the pair
+   stays consistent and `path/to` leaves the output vocabulary. Where the
+   NL never named it (every tldr `Create specific files` → `touch
+   path/to/file1 path/to/file2`), or there is no safe name (`<port>`,
+   `<package>`), the row is dropped. Keystrokes (`<Ctrl x>`, `<Enter>`,
+   `<q>`) are not placeholders and stay. 1,012 rows rewritten, 55,246
+   dropped. Rewritten commands are the only ones in the pool not
+   byte-identical to source; the diff is the placeholder token and nothing
+   else.
+2. Cap. 300 rows per first token for tools outside CORE (rebalance.py's
+   list plus every tool basics.txt teaches, plus shell keywords `for`,
+   `while`, `if`, `until`, `case`, which are composition, not tools).
+   Sampled by whole pair so the four registers of a command stay together.
+   15,754 rows dropped from 61 tools (`az`, `aws`, `kubectl`, `cargo`,
+   `gh`, `tlmgr`, `pio`, `shuf`, … each 1,200 → 300).
+3. `find` to 5% of the final pool. It is core and genuinely common, but at
+   17% it is the answer the model reaches for when unsure; 5% still leaves
+   it the single largest tool. 46,364 rows dropped. basics rows are exempt
+   from every rule.
+
+| | pool_v6 (run 8) | **pool_v7** |
+|---|---|---|
+| rows | 345,721 | **228,357** (−34%) |
+| distinct first tokens | 4,819 | 4,102 |
+| top-30 share | 35.3% | 29.4% |
+| rows with a placeholder in cmd | 56,258 (16.3%) | **0** |
+| `find` share | 16.9% (58,365) | 5.0% (11,484) |
+| `touch` / `mkdir` / `useradd` | 535 / 959 / 116 | 454 / 918 / 104 |
+| `az` / `aws` / `kubectl` / `shuf` | 1,200 each | 300 each |
+| `fossil` / `skicka` / `kcadm.sh` | 151 / 66 / 38 | 91 / 0 / 30 |
+| by source (nl2sh_train / tldr / extra / basics) | 187,891 / 95,848 / 59,401 / 2,581 | 109,995 / 66,758 / 49,047 / 2,581 |
+
+The `touch` rows lost are exactly the placeholder ones; every surviving
+`touch` names a real file. `nl2sh_train` lost the most: 26,869 of its
+rows carried `path/to` because that pool was itself partly tldr-derived.
+
+**Hand-read, 200 rows, `random.Random(42).sample`.** Registers read as
+intended: colloquial and rojak natural (`tlg buang all file _* and
+.DS_Store`, `nak tengok status semua job je kat sini`), formal circular-ish
+by design. Nothing prior.py rewrote read wrong (30 rewritten rows read
+separately: `Remount "bin"` and `mount device location` are dull but
+consistent on both sides). What did read wrong is older pool noise, none of
+it in this issue's scope, all counted so it can be its own issue: 246 rows
+whose command starts with a `$ ` prompt (`$ find /dev ...`, first token
+`$`); 11,779 rows (5%) with tldr's alternation syntax in the command
+(`ctest [-j|--parallel] 4`, `komac bash|elvish|fish|zsh`), which is not a
+runnable command; 139 `path\to\key` (wine reg, backslashes); 217
+`some_command`/`command1` placeholders; 48 rows where NL is the command
+itself; a few Indonesian slips (`kota`, `acak`) the stoplist does not
+know; and a handful of mismatched `extra` pairs (`Hapus entri dalam fail
+.bash_history` → `export HISTCONTROL=ignoreboth`).
+
+**Measure.** Run 7 to beat: ALFA BM 0.487 / rojak 0.490 / EN 0.543, probe
+basics 0.90 / holdout 0.78; run 8 for the same-rows comparison. New
+number: placeholder rate on the probe outputs (`path/to` or `<name>` in the
+answer), reported alongside. Then #47's exact-output prompts, `compare.py`
+vs run 7, bench, all with #57's error bar in mind.
+
+GPU command, from the worktree's `training/`:
+`./rebuild.sh qwen-v7 ../dataset/out/pool_v7.jsonl` — queued behind the
+running job, one at a time (#56, #57).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1032,3 +1032,66 @@ is inside run 7's CI on every register and −0.02 EN on its own base.
 Next, if this thread continues: weight the real-mistake pairs (1.2% of the
 set today), or grow the head of the pool for the beginner verbs (#54's
 note) and DPO on top of that — the pool sets the prior, DPO trims it.
+
+
+## Retrieval over tldr in the prompt (issue #55)
+
+The issue says the cost measurement decides, so it comes first. Everything
+below is the pinned CPU build (`b10333`), `-ngl 0`, run 7 GGUF
+(`qwen-v5-Q4_K_M`), same decoding as `bench.py`, `training/bench_retrieval.py`.
+The GPU was busy with a training job while this ran, so absolute numbers
+carry that noise; the baseline row reproduces run 7's bench within it.
+
+**Embedding model.** `bge-small-en-v1.5` f16 GGUF, 67 MB on disk (the
+`bge-small / e5-small / arctic-xs` class the issue names; English-only, which
+matters below). Served by the same pinned `llama-server` with `--embeddings
+--pooling cls -c 512`: 0.2 s to load, **101 MB RSS**, **6–9 ms** per query
+embed at 2–4 threads. The embedder is not the cost.
+
+**Index.** `dataset/raw/tldr.csv` deduped on (description, command): 29,153
+lines, description embedded, line shape `description: command`. Vectors
+29,153 × 384 f16 = **22 MB** (the `.npz` with the text is 70 MB); building
+it is 4 min of CPU at 4 threads. Query → top-3 is 16–21 ms end to end.
+
+**Cost, both servers resident, 12 queries, median.** Three (or one)
+*distinct* tldr lines per query — a fixed set is not a measurement: the
+pinned server keeps evicted prompts in RAM and served a rotated fixed set
+from cache at 13 prompt tokens instead of 80.
+
+| threads | prompt | prompt tokens evaluated | warm s (max) | tok/s | combined RSS MB |
+|---|---|---|---|---|---|
+| 2 | baseline | 12 | 0.73–0.77 (1.4–1.7) | 26–27 | 1768 |
+| 2 | + top-3 `Examples:` | 80 | **2.06–2.18 (3.1)** | 26–28 | 1817 |
+| 2 | + top-1 | 31 | 1.10 (1.6) | 28 | 1821 |
+| 4 | baseline | 12 | 0.43–0.53 (0.8–1.3) | 30–42 | 1768 |
+| 4 | + top-3 `Examples:` | 80 | **1.30–1.31 (1.8)** | 38–41 | 1813 |
+| 4 | + top-1 | 31 | 0.61 (1.0) | 42 | 1816 |
+
+Two runs, both shown where they differ. RSS is not the problem: 1.8 GB
+combined, 0.7 GB under the ceiling. Prompt evaluation is: the tuned 1.5B
+processes prompt tokens at ~60–80 tok/s on 2 threads, so 68 extra tokens
+per query is 1.3 s before the first output token, every query, because the
+retrieved lines differ per query and defeat `cache_prompt`.
+
+**Verdict vs constraint 3.** `engine.go` gives a 4-core box 2 threads. At 2
+threads top-3 retrieval is **2.1 s median, 3.1 s worst**, over the 1.5 s
+warm budget on a host that is already faster than the target box. At 4
+threads it is 1.3 s median with a 1.8 s tail: under the median budget here,
+over it on the target. **Top-3 as the issue specifies does not fit.** Top-1
+fits (1.1 s at 2 threads, 0.6 s at 4), with less headroom than baseline and
+one line of context instead of three, so it is measured below rather than
+assumed useless.
+
+**Hypothesis, written before the probe run.** With top-1 retrieval on, the
+run 7 model will gain on the probe's holdout block (tools absent from
+basics.txt: `truncate`, `tac`, `tee`, `timeout`, `chsh`, `printenv`, `nl`)
+by ≥ +0.05, because for those tasks the right tldr line is the answer, and
+hold basics tasks within 0.02, because those the model already knows. Two
+things say the gain will be smaller than the idea promises: the embedder is
+English-only, so Malay phrasings that carry no English technical noun
+retrieve wrong lines (`nak buat file baru` → `hexedit`, `kioclient`;
+spot-checked before the run), and a bad line in front of a 1.5B model is a
+distractor, not a no-op. Falsified if holdout does not move or basics
+drops; then retrieval needs a multilingual embedder (`multilingual-e5-small`
+Q8 is ~120 MB, over the issue's cap) or a retrained model that has seen
+`Examples:` in training, both out of scope here.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -870,3 +870,40 @@ vs run 7, bench, all with #57's error bar in mind.
 GPU command, from the worktree's `training/`:
 `./rebuild.sh qwen-v7 ../dataset/out/pool_v7.jsonl` — queued behind the
 running job, one at a time (#56, #57).
+
+**Result (2026-08-17): the pool prior moves the probe, not ALFA.** `qwen-v7`,
+228,357 rows, 2 h 40 min train on the 3090. Error bar from #57: same recipe
+reproduces to ≤ 0.013 per register.
+
+| register | run 7 | run 9 (v7) | diff | 95% CI | lost / gained | p |
+|---|---|---|---|---|---|---|
+| BM | 0.487 | 0.513 | +0.027 | [−0.029, +0.083] | 33 / 41 | 0.42 |
+| rojak | 0.490 | 0.517 | +0.027 | [−0.026, +0.080] | 29 / 37 | 0.39 |
+| EN | 0.543 | 0.563 | +0.020 | [−0.036, +0.076] | 34 / 40 | 0.56 |
+
+All three registers up, none clears its CI. The churn is the story: ~35
+tasks lost and ~40 gained per register — ten times run 7 vs v5b — so a
+34% pool cut is a different model, and 300 tasks cannot say whether it is
+a better one. English did not drop, so the run-2 fear did not come true.
+
+Probe: 199 / 222 both, not the same 199. What the issue was for is fixed:
+`create file` 8/9 → 9/9 (`touch newfile.txt` on every phrasing, no more
+`fossil add path/to/file`), `create folder` 8/8, `create user` 2/5 → **5/5**
+(`sudo useradd -m newuser`, no more `kcadm.sh`), placeholder answers
+29 → **6** across the 222 prompts. What broke: `delete file` ×4 →
+`git obliterate file_1 file_2 ...` (was `rm path/to/file1 ...`, tool-right
+placeholder), `list processes` ×3 → `pm2 list`/`pm2 monit` (was `ps aux`),
+`edit file` → `less`, holdout 36 → 33 (`chsh`, `timeout`, `whereis` lost;
+`tee` ×2, `reverse lines/en` gained). `rm` and `ps` rows barely moved
+(1,618 → 1,539, 928 → 868); what moved is share — the core list is
+uncapped, so `git` went from 4.3% to 5.8% of the pool and `pm2` (84 rows,
+under the cap) from 0.02% to 0.04%. Capping the tail without growing the
+head redistributes the prior, it does not flatten it. Bench unchanged
+(4 threads 0.53 s warm, 39 tok/s, 1.49 GB RSS).
+
+Verdict: not shipping on ALFA alone (inside CI, per #57's protocol), but
+the probe targets #47/#53/#54 exist for are met on this pool. The next
+pool change should add head rows for the beginner verbs (`rm`, `ps`,
+`nano`) rather than cut more tail — and #56's DPO pairs already encode
+exactly the `git obliterate`/`pm2` class of miss, so DPO on this
+checkpoint (`DPO_BASE=out/qwen-v7-lora-merged`) is the cheap next arm.

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -20,6 +20,10 @@ augment_verbs.py  # → out/pool_v3.aug.jsonl    fill in Malay verbs the
                   # translator never reached for (`cipta` had 2 rows)
 rebalance.py      # → out/pool_v3.bal.jsonl    fix the tool-frequency
                   # inversion (`shuf` outweighed `touch` 11 to 1)
+basics.py         # basics.txt → out/basics.jsonl  hand-written beginner rows
+prior.py          # pool_v6 (= pool_v4.bal + basics) → out/pool_v7.jsonl
+                  # drop/rewrite path/to placeholders, cap the long tail at
+                  # 300, find to 5% (issue #54)
 ```
 
 Full rebuild from raw, no GPU:

--- a/dataset/prior.py
+++ b/dataset/prior.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fix the pool's tool prior (issue #54). Stdlib only.
+
+  python3 prior.py out/pool_v6.jsonl out/pool_v7.jsonl
+
+pool_v6 is pool_v4.bal + basics.jsonl. Three tuned models answered `nak buat
+file baru` with `touch path/to/file1 path/to/file2` or `fossil add`: 14.7%
+of rows carry a tldr placeholder in the command, `find` is 17% of the pool
+and 4,800 distinct first tokens split the rest. Three rules, in this order:
+
+  placeholders  `path/to/...` and `<name>` in the command. If every one also
+                appears verbatim in the NL (the user typed the path), rewrite
+                both sides to a concrete name so the pair stays consistent
+                and `path/to` leaves the output vocabulary. Otherwise the NL
+                never named what the command names — drop. Keystrokes
+                (`<Ctrl c>`, `<Enter>`, `<q>`) are not placeholders and stay.
+  --cap N       rows per first token for tools outside CORE (rebalance.py's
+                list plus every tool basics.txt teaches). Whole pairs are
+                sampled, seed 42, so the four registers stay together.
+  --find-share  `find` is core and genuinely common, but 17% is a prior no
+                task set has; a model that is unsure reaches for it. Sampled
+                down to this share of the final pool.
+
+basics.jsonl rows are never dropped. Rewritten commands are the only ones
+not byte-identical to source; the rewrite touches nothing but the
+placeholder token, and the same token in the NL.
+"""
+import argparse
+import json
+import random
+import re
+from collections import Counter, defaultdict
+
+from basics import parse
+from rebalance import CORE, tool
+
+# Shell keywords are not tools; a loop is composition, not a long-tail prior.
+KEYWORDS = {"for", "while", "if", "until", "case"}
+NAMES = {"file": "notes.txt", "filename": "notes.txt", "directory": "projek",
+         "dir": "projek", "folder": "projek"}
+KEYS = {"ctrl", "alt", "shift", "esc", "escape", "enter", "return", "space",
+        "tab", "backspace", "del", "delete", "up", "down", "left", "right",
+        "home", "end", "pageup", "pagedown", "pgup", "pgdn", "super", "cmd",
+        "meta", "fn", "insert", "cr"} | {f"f{i}" for i in range(1, 13)}
+PATH = re.compile(r"path/to/[\w./-]*\w")
+ANGLE = re.compile(r"<[A-Za-z][\w -]+>")   # `<q>`, `<p>` are a key / a tag
+
+
+def concrete(ph):
+    """`path/to/dir_a` -> `dir_a`, `<file>` -> `notes.txt`; None = no safe name."""
+    if ph.startswith("<"):
+        name = ph[1:-1].split()[0].lower()
+        return None if name in KEYS else NAMES.get(name)
+    name = ph.rstrip("/").split("/")[-1]
+    return NAMES.get(name, name)
+
+
+def rewrite(nl, cmd):
+    """(nl, cmd) with placeholders made concrete, or None to drop."""
+    phs = PATH.findall(cmd) + [p for p in ANGLE.findall(cmd)
+                               if p[1:-1].split()[0].lower() not in KEYS]
+    if any(ph not in nl or concrete(ph) is None for ph in phs):
+        return None
+    for ph in dict.fromkeys(phs):
+        # `/path/to/x` and `path/to/x` alike; `/remote/path/to/x` keeps `/remote/`
+        pat = r"(?:(?<![\w/])/)?" + re.escape(ph)
+        nl, cmd = re.sub(pat, concrete(ph), nl), re.sub(pat, concrete(ph), cmd)
+    if "path/to" in cmd:              # `path/to/*.txt`, `path/to new/dir`
+        return None
+    return nl, cmd
+
+
+def sample_ids(rows, keep_rows, seed=42):
+    """Deterministic pair-level cut: ids to keep so that ~keep_rows survive."""
+    by_id = defaultdict(int)
+    for r in rows:
+        by_id[r["id"]] += 1
+    ids = sorted(by_id)
+    random.Random(seed).shuffle(ids)
+    kept, n = set(), 0
+    for i in ids:
+        if n >= keep_rows:
+            break
+        kept.add(i)
+        n += by_id[i]
+    return kept
+
+
+def report(label, rows):
+    cnt = Counter(tool(r["cmd"]) for r in rows)
+    top30 = sum(n for _, n in cnt.most_common(30))
+    ph = sum(1 for r in rows if rewrite(r["nl"], r["cmd"]) != (r["nl"], r["cmd"]))
+    print(f"{label}: {len(rows)} rows, {len(cnt)} first tokens, "
+          f"top-30 share {100*top30/len(rows):.1f}%, placeholders {ph}, "
+          f"find {100*cnt['find']/len(rows):.1f}%")
+    return cnt
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--cap", type=int, default=300)
+    ap.add_argument("--find-share", type=float, default=0.05)
+    ap.add_argument("--basics", default="basics.txt")
+    args = ap.parse_args()
+
+    rows = [json.loads(l) for l in open(args.src, encoding="utf-8")]
+    before = report("before", rows)
+    core = set(CORE) | KEYWORDS | {tool(cmd) for cmd, _ in parse(args.basics)}
+    hand = lambda r: r["id"].startswith("basics:")
+
+    # 1. placeholders
+    kept, rewritten, dropped_ph = [], 0, 0
+    for r in rows:
+        got = rewrite(r["nl"], r["cmd"])
+        if got is None:
+            dropped_ph += 1
+            continue
+        if got != (r["nl"], r["cmd"]):
+            rewritten += 1
+            r = {**r, "nl": got[0], "cmd": got[1]}
+        kept.append(r)
+    rows = kept
+
+    # 2. cap the long tail, whole pairs
+    by_tool = defaultdict(list)
+    for r in rows:
+        by_tool[tool(r["cmd"])].append(r)
+    keep_ids = set()
+    for t in sorted(by_tool):
+        rs = by_tool[t]
+        if t in core or len(rs) <= args.cap:
+            keep_ids.update(r["id"] for r in rs)
+        else:
+            keep_ids |= sample_ids(rs, args.cap)
+    kept = [r for r in rows if hand(r) or r["id"] in keep_ids]
+    dropped_cap = len(rows) - len(kept)
+    rows = kept
+
+    # 3. find down to --find-share of the final pool
+    finds = [r for r in rows if tool(r["cmd"]) == "find" and not hand(r)]
+    others = len(rows) - len(finds)
+    want = int(others * args.find_share / (1 - args.find_share))
+    keep_ids = sample_ids(finds, want) if len(finds) > want else {r["id"] for r in finds}
+    kept = [r for r in rows if hand(r) or tool(r["cmd"]) != "find" or r["id"] in keep_ids]
+    dropped_find = len(rows) - len(kept)
+    rows = kept
+
+    print(f"placeholders: rewrote {rewritten}, dropped {dropped_ph}; "
+          f"cap {args.cap}: dropped {dropped_cap}; "
+          f"find -> {args.find_share:.0%}: dropped {dropped_find}")
+    after = report("after", rows)
+    for t in ("find", "touch", "mkdir", "useradd", "tar", "az", "aws", "kubectl",
+              "shuf", "fossil", "skicka", "kcadm.sh", "ss", "lsof"):
+        print(f"  {t:10s} {before.get(t,0):>7} -> {after.get(t,0):>7}")
+    with open(args.dst, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"wrote {len(rows)} rows -> {args.dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dataset/test_pipeline.py
+++ b/dataset/test_pipeline.py
@@ -219,3 +219,36 @@ _by = {}
 for _r in _b:
     _by.setdefault(_r["id"].split(".")[0], set()).add(_r["cmd"])
 assert all(len(v) == 1 for v in _by.values())
+
+# --- prior.py (issue #54: placeholder rewrite + long-tail cap) --------------
+from prior import rewrite, sample_ids
+
+for nl, cmd, want in (
+        # user typed the path: rewrite both sides, `path/to` leaves the command
+        ("senarai folder kat /path/to/dir", "find /path/to/dir -type d",
+         ("senarai folder kat projek", "find projek -type d")),
+        ("copy /path/to/data/app ke host:/remote/path/to/data/app",
+         "rsync -r /path/to/data/app host:/remote/path/to/data/app",
+         ("copy app ke host:/remote/app", "rsync -r app host:/remote/app")),
+        ("nak tengok fail <file>", "ncdu -f <file>", ("nak tengok fail notes.txt", "ncdu -f notes.txt")),
+        # NL never named it: drop
+        ("Create specific files", "touch path/to/file1 path/to/file2", None),
+        ("nak update package ni", "snap refresh <package>", None),
+        # NL names it but there is no safe concrete name for `<port>`: drop
+        ("proses kat port <port>", "netstat -pln | grep <port>", None),
+        # unmatched placeholder shapes: drop
+        ("delete files on the server", "mrm path/to/*.txt", None),
+        # keystrokes and HTML tags are not placeholders
+        ("nak keluar nano", "<Ctrl x>", ("nak keluar nano", "<Ctrl x>")),
+        ("quit less", "<q>", ("quit less", "<q>")),
+        ("first paragraph", "grep -o '<p>[^<]*</p>' page.html", ("first paragraph", "grep -o '<p>[^<]*</p>' page.html")),
+        ("nothing to do", "ls -la", ("nothing to do", "ls -la"))):
+    assert rewrite(nl, cmd) == want, (nl, cmd, rewrite(nl, cmd))
+
+# cap: whole pairs, deterministic, lands at or just past the target
+_rows = [{"id": f"t:{i}", "register": reg} for i in range(50)
+         for reg in ("formal", "colloquial", "rojak", "english")]
+_k = sample_ids(_rows, 30)
+assert _k == sample_ids(_rows, 30) and 30 <= 4 * len(_k) < 34, _k
+assert sample_ids(_rows, 1000) == {f"t:{i}" for i in range(50)}
+print("ok: prior checks pass")

--- a/training/bench_retrieval.py
+++ b/training/bench_retrieval.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Constraint-3 cost of retrieval (issue #55): an embedding server resident
+next to the generator, and three `Examples:` lines prepended to the user turn.
+
+  python3 bench_retrieval.py out/qwen-v5-Q4_K_M.gguf out/bge-small-en-v1.5-f16.gguf
+
+CPU only, pinned llama-server, 4 threads (what ships). Reports embed latency
+and RSS of the embedding server, then the generator's warm latency / tok/s /
+RSS with the baseline prompt and with the retrieval prompt, both servers up.
+Same decoding as bench.py. Combined RSS is what constraint 3 gates.
+"""
+import argparse
+import json
+import os
+import re
+import signal
+import statistics
+import subprocess
+import sys
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench import QUERIES, SYSTEM, rss_mb  # noqa: E402
+
+PINNED = os.path.expanduser("~/.cache/camne/bin/llama-b10333/llama-server")
+GEN_PORT, EMB_PORT = 18097, 18098
+
+# Three tldr one-liners in the shape retrieve.py will produce; ~150 tokens
+# is the budget the issue names, so pad to that shape rather than the
+# shortest lines in the pool.
+TLDR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "dataset", "raw", "tldr.csv")
+
+
+def examples(i, k=3):
+    """Real retrieval returns different lines per query, so the prompt cache
+    covers the system turn only. Rotating one fixed set is not enough: the
+    pinned server keeps several evicted prompts in RAM and served the third
+    ordering from cache (prompt_n 13, not ~90). Three distinct tldr lines per
+    query, 36 in all, no two queries share one."""
+    import csv
+    rows = [r for r in csv.DictReader(open(TLDR, encoding="utf-8"))
+            if 60 <= len(r["nl"]) + len(r["bash"]) <= 110][100:136]
+    lines = [f"{r['nl']}: {r['bash']}" for r in rows[3 * i:3 * i + k]]
+    return "Examples:\n" + "\n".join(lines) + "\nRequest: "
+
+
+def wait(port):
+    t0 = time.monotonic()
+    while True:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=2)
+            return time.monotonic() - t0
+        except Exception:
+            if time.monotonic() - t0 > 300:
+                raise RuntimeError("server never became ready")
+            time.sleep(0.2)
+
+
+def post(port, path, body, timeout=600):
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+
+def ask(q, i=0, k=0):
+    prefix = examples(i, k) if k else ""
+    prompt = (f"<|im_start|>system\n{SYSTEM}<|im_end|>\n"
+              f"<|im_start|>user\n{prefix}{q}<|im_end|>\n<|im_start|>assistant\n")
+    t0 = time.monotonic()
+    d = post(GEN_PORT, "/completion", {
+        "prompt": prompt, "n_predict": 64, "temperature": 0,
+        "grammar": "root ::= [ -~]+", "stop": ["\n"],
+        "repeat_penalty": 1.08, "repeat_last_n": 64, "cache_prompt": True})
+    tm = d.get("timings", {})
+    return time.monotonic() - t0, tm.get("predicted_per_second", 0), tm.get("prompt_n", 0)
+
+
+def embed(q):
+    t0 = time.monotonic()
+    post(EMB_PORT, "/v1/embeddings", {"input": q}, timeout=60)
+    return time.monotonic() - t0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("gen")
+    ap.add_argument("emb")
+    ap.add_argument("--server", default=PINNED)
+    ap.add_argument("--threads", default="2,4")
+    a = ap.parse_args()
+    res = [run(a, int(t)) for t in a.threads.split(",")]
+    with open("out/bench_retrieval.json", "w") as f:
+        json.dump(res, f, indent=1)
+
+
+def run(a, threads):
+    a.threads = threads
+    common = ["-t", str(a.threads), "-ngl", "0", "--no-webui"]
+    emb = subprocess.Popen([a.server, "-m", a.emb, "--embeddings", "--pooling", "cls",
+                            "-c", "512", "-b", "512", "-ub", "512", "--port", str(EMB_PORT)] + common,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    gen = subprocess.Popen([a.server, "-m", a.gen, "-c", "2048", "--port", str(GEN_PORT)] + common,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        emb_load = wait(EMB_PORT)
+        gen_load = wait(GEN_PORT)
+        embed(QUERIES[0])
+        emb_lat = statistics.median(embed(q) for q in QUERIES)
+        emb_rss = rss_mb(emb.pid)
+        out = {"emb_model": os.path.basename(a.emb), "emb_mb": round(os.path.getsize(a.emb) / 1e6),
+               "emb_load_s": round(emb_load, 2), "gen_load_s": round(gen_load, 2),
+               "emb_ms": round(emb_lat * 1000, 1), "emb_rss_mb": round(emb_rss), "threads": a.threads}
+        for name, k in (("baseline", 0), ("retrieval", 3), ("retrieval_top1", 1)):
+            ask(QUERIES[0], 0, k)  # warm the cache
+            lat, tps, pn = zip(*(ask(q, i, k) for i, q in enumerate(QUERIES)))
+            out[name] = {"warm_s": round(statistics.median(lat), 3),
+                         "warm_max_s": round(max(lat), 3),
+                         "tok_s": round(statistics.median(tps), 1),
+                         "prompt_tokens": int(statistics.median(pn)),
+                         "gen_rss_mb": round(rss_mb(gen.pid)),
+                         "combined_rss_mb": round(rss_mb(gen.pid) + emb_rss)}
+        # end-to-end warm: embed + generate with the longer prompt
+        for name in ("retrieval", "retrieval_top1"):
+            out[name]["warm_e2e_s"] = round(out[name]["warm_s"] + emb_lat, 3)
+        print(json.dumps(out, indent=1))
+        return out
+    finally:
+        for p in (emb, gen):
+            p.send_signal(signal.SIGTERM)
+            p.wait(timeout=30)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/dpo.py
+++ b/training/dpo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""DPO stage on top of a merged SFT checkpoint (issue #56).
+
+  uv run dpo.py                                   # run 7 merged -> out/qwen-v5-dpo-lora
+  uv run dpo.py --base-ckpt out/X-lora-merged --data out/dpo_pairs.jsonl --out out/X-dpo-lora
+  ./finish.sh out/qwen-v5-dpo-lora-merged qwen-v5-dpo
+
+One variable vs the SFT run it sits on: this stage. Fresh LoRA (same
+r32/a64/all-linear as train.py) on the merged checkpoint, TRL DPOTrainer,
+sigmoid loss, beta 0.1, 1 epoch, seed 42, effective batch 32. Reference
+model is the same weights with the adapter disabled (TRL's default for
+PEFT), so no second copy in VRAM. bf16 LoRA, not QLoRA.
+
+Pairs come from dpo_pairs.py: {prompt, chosen, rejected}. The prompt is
+wrapped in the same literal ChatML as train.py; chosen/rejected are the bare
+commands and TRL appends eos (<|im_end|> for Qwen) itself, so the training
+text is byte-identical in shape to the SFT rows.
+"""
+import argparse
+import json
+
+from unsloth import FastLanguageModel, PatchDPOTrainer  # before transformers
+from datasets import Dataset
+from trl import DPOConfig, DPOTrainer
+
+from train import CHATML, SYSTEM
+
+PatchDPOTrainer()
+PROMPT = CHATML.split("{cmd}")[0]   # ChatML up to and including "assistant\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-ckpt", default="out/qwen-v5-lora-merged")
+    ap.add_argument("--data", default="out/dpo_pairs.jsonl")
+    ap.add_argument("--out", default="out/qwen-v5-dpo-lora")
+    ap.add_argument("--micro-batch", type=int, default=8,
+                    help="DPO holds chosen+rejected+ref per row; keep the product 32")
+    ap.add_argument("--grad-accum", type=int, default=4)
+    ap.add_argument("--lr", type=float, default=5e-6,
+                    help="Unsloth's DPO reference recipe; SFT's 2e-4 would wreck the policy")
+    args = ap.parse_args()
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        args.base_ckpt, max_seq_length=192, dtype=None, load_in_4bit=False,
+    )
+    model = FastLanguageModel.get_peft_model(
+        model, r=32, lora_alpha=64, lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+        use_gradient_checkpointing="unsloth", random_state=42,
+    )
+
+    rows = [json.loads(l) for l in open(args.data, encoding="utf-8")]
+    ds = Dataset.from_list([{
+        "prompt": PROMPT.format(sys=SYSTEM, nl=r["prompt"]),
+        "chosen": r["chosen"], "rejected": r["rejected"],
+    } for r in rows]).shuffle(seed=42)
+    print(f"{len(ds)} pairs from {args.data}")
+
+    trainer = DPOTrainer(
+        model=model, ref_model=None, processing_class=tokenizer, train_dataset=ds,
+        args=DPOConfig(
+            output_dir=args.out,
+            beta=0.1,
+            loss_type="sigmoid",
+            per_device_train_batch_size=args.micro_batch,
+            gradient_accumulation_steps=args.grad_accum,
+            num_train_epochs=1,
+            learning_rate=args.lr,
+            lr_scheduler_type="cosine",
+            warmup_ratio=0.03,
+            max_prompt_length=128,
+            max_completion_length=64,
+            max_length=192,
+            bf16=True,
+            seed=42,
+            logging_steps=10,
+            save_strategy="epoch",
+            report_to="none",
+        ),
+    )
+    trainer.train()
+
+    # merged bf16 checkpoint; finish.sh takes it from here
+    model.save_pretrained_merged(args.out + "-merged", tokenizer, save_method="merged_16bit")
+    print(f"merged model at {args.out}-merged")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/dpo_pairs.py
+++ b/training/dpo_pairs.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Preference pairs from the model's own mistakes (issue #56). Stdlib only.
+
+  python3 dpo_pairs.py                       # -> out/dpo_pairs.jsonl
+  python3 dpo_pairs.py --probe out/probe_X.jsonl
+
+SFT teaches what to say; DPO can also teach what not to say. Three kinds of
+pair, every one {prompt, chosen, rejected, kind}:
+
+  probe-wrong        probe prompt run 7 failed; chosen = the basics.txt
+                     command for that probe task, rejected = what it printed
+  probe-placeholder  probe prompt it passed tool-level but answered with a
+                     tldr `path/to/...` placeholder; same chosen/rejected rule
+  synth-placeholder  every basics.txt row; rejected = the gold with its
+                     names swapped for `path/to/file` / `path/to/directory`
+  synth-tool-swap    every basics.txt row; rejected = the gold with its tool
+                     swapped for an obscure tool that exists in the pool
+                     (`fossil add`, `skicka mkdir`, `kcadm.sh` — the ones run 7
+                     actually reached for — or one drawn from OBSCURE, seed 42)
+
+Split, stated: ALFA is never touched. Any pair whose prompt is an
+eval_bm_300 / eval_rojak_300 / nl2sh_test prompt is dropped (three basics.txt
+English phrasings collide with nl2sh_test), so the ALFA numbers stay clean.
+The probe is NOT clean after this: probe-* pairs train on the probe's own
+prompts, so post-DPO probe basics-task numbers measure recall, not
+generalisation. HOLDOUT (no basics.txt command to use as
+chosen) and the homograph guard get no pairs and stay clean.
+"""
+import argparse
+import collections
+import csv
+import json
+import os
+import random
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "dataset"))
+from basics import parse as parse_basics  # noqa: E402
+
+# probe.py task -> the basics.txt command for it, with the probe's own names
+# (readme.txt, invoice.pdf, 10.0.0.5 ...) where the prompt carries one.
+GOLD = {
+    "create file": "touch newfile.txt",
+    "create folder": "mkdir newfolder",
+    "delete file": "rm notes.txt",
+    "list files": "ls",
+    "copy file": "cp report.pdf /tmp",
+    "rename file": "mv old.txt new.txt",
+    "disk space": "df -h",
+    "list processes": "ps aux",
+    "kill process on port": "kill $(lsof -t -i:8080)",
+    "open firewall port": "sudo ufw allow 22",
+    "change permission": "chmod +x script.sh",
+    "create user": "sudo useradd -m newuser",
+    "compress folder": "tar -czf folder.tar.gz folder",
+    "search text in files": 'grep -r "error" .',
+    "download a url": "wget https://example.com/a.txt",
+    "read file": "cat readme.txt",
+    "find file by name": "find . -name invoice.pdf",
+    "where am i": "pwd",
+    "my ip": "ip a",
+    "edit file": "nano readme.txt",
+    "exit vim": "<Esc>:q<Enter>",
+    "exit nano": "<Ctrl x>",
+    "extract archive": "tar -xzf data.tar.gz",
+    "move file": "mv report.pdf Documents/",
+    "count lines": "wc -l data.csv",
+    "check internet": "ping -c 4 8.8.8.8",
+    "git commit": 'git commit -m "add login"',
+    "install package": "sudo apt install htop",
+    "run script": "bash deploy.sh",
+    "follow log": "tail -f server.log",
+    "ram usage": "free -h",
+    "ssh into server": "ssh ariff@10.0.0.5",
+    "history": "history",
+    "empty folder delete": "rmdir temp",
+    "copy folder": "cp -r website website_old",
+}
+
+# What run 7 actually answered with (probe_qwen-v5, RESULTS.md run 8 table).
+KNOWN_SWAP = {
+    "touch": "fossil add", "mkdir": "skicka mkdir",
+    "useradd": "kcadm.sh create users", "tar": "lzop", "df": "gdu",
+    "du": "gdu", "kill": "fkill", "pkill": "fkill", "free": "smem",
+    "ps": "jobs", "rmdir": "tempdir -c", "whereis": "whereis -f",
+}
+# Obscure tools that exist in the pool (asserted against --pool at start).
+OBSCURE = ["fossil", "skicka", "kcadm.sh", "fkill", "gdu", "lzop", "smem",
+           "abduco", "croc", "duf", "dust", "procs", "tmsu", "xh", "skate",
+           "atool", "unar", "lsd", "eza", "bfs"]
+
+DIR_TOOLS = {"mkdir", "rmdir", "cd", "ls", "tree", "du"}
+FILE_TOK = re.compile(r"^[\w./-]*\w\.[a-z][a-z0-9]{0,4}$")
+HOST_TOK = re.compile(r"\.(com|org|net|io|me|dev|my)$")
+
+
+def split_tool(cmd):
+    """(prefix, tool, rest) — prefix is 'sudo ' or ''; tool is the first word."""
+    toks = cmd.split(" ")
+    pre = ""
+    if toks[0] == "sudo" and len(toks) > 1:
+        pre, toks = "sudo ", toks[1:]
+    return pre, toks[0], toks[1:]
+
+
+def placeholder(cmd):
+    """Gold with names swapped for path/to/...; None if nothing to swap."""
+    pre, tool, rest = split_tool(cmd)
+    out, hit = [], False
+    for t in rest:
+        if t.startswith("-") or "://" in t or HOST_TOK.search(t):
+            out.append(t)
+        elif t.endswith("/") or (tool in DIR_TOOLS and t[0].isalnum()):
+            out.append("path/to/directory")
+            hit = True
+        elif FILE_TOK.match(t):
+            out.append("path/to/file")
+            hit = True
+        else:
+            out.append(t)
+    return f"{pre}{tool} {' '.join(out)}".rstrip() if hit else None
+
+
+def tool_swap(cmd, rng):
+    """Gold with its tool replaced by an obscure pool tool; None if no tool."""
+    pre, tool, rest = split_tool(cmd)
+    if not tool[0].isalpha():   # <Ctrl x>, <Esc>:q<Enter>, `.`, `~`
+        return None
+    swap = KNOWN_SWAP.get(tool) or rng.choice(OBSCURE)
+    return " ".join([swap] + rest)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--probe", default="out/probe_qwen-v5.jsonl")
+    ap.add_argument("--basics", default="../dataset/basics.txt")
+    ap.add_argument("--pool", default="../dataset/out/pool_v5.jsonl")
+    ap.add_argument("--out", default="out/dpo_pairs.jsonl")
+    args = ap.parse_args()
+    os.chdir(HERE)
+
+    pool_tools = {split_tool(json.loads(l)["cmd"])[1]
+                  for l in open(args.pool, encoding="utf-8")}
+    missing = [t for t in OBSCURE if t not in pool_tools]
+    assert not missing, f"not in {args.pool}: {missing}"
+
+    pairs = []
+    for r in map(json.loads, open(args.probe, encoding="utf-8")):
+        if r["task"] not in GOLD:      # holdout / homograph: no gold, stays clean
+            continue
+        gold = GOLD[r["task"]]
+        if r["got"] == gold:
+            continue
+        if not r["ok"]:
+            kind = "probe-wrong"
+        elif "path/to" in r["got"]:
+            kind = "probe-placeholder"
+        else:
+            continue
+        pairs.append({"prompt": r["prompt"], "chosen": gold,
+                      "rejected": r["got"], "kind": kind})
+
+    rng = random.Random(42)
+    for cmd, regs in parse_basics(args.basics):
+        rej = {"synth-placeholder": placeholder(cmd),
+               "synth-tool-swap": tool_swap(cmd, rng)}
+        for kind, bad in rej.items():
+            if bad and bad != cmd:
+                for nl in (p for ps in regs.values() for p in ps):
+                    pairs.append({"prompt": nl, "chosen": cmd,
+                                  "rejected": bad, "kind": kind})
+
+    # ALFA stays clean: no pair prompt is an eval prompt.
+    alfa = set()
+    for name in ("eval_bm_300.jsonl", "eval_rojak_300.jsonl"):
+        alfa |= {json.loads(l)["nl"].lower()
+                 for l in open(f"../dataset/{name}", encoding="utf-8")}
+    with open("../dataset/raw/nl2sh_test.csv", newline="", encoding="utf-8") as f:
+        alfa |= {r["nl"].lower() for r in csv.DictReader(f)}
+    leaked = sorted({p["prompt"] for p in pairs if p["prompt"].lower() in alfa})
+    pairs = [p for p in pairs if p["prompt"].lower() not in alfa]
+    print(f"dropped {len(leaked)} prompts that are ALFA eval prompts: {leaked}")
+
+    seen, uniq = set(), []
+    for p in pairs:
+        k = (p["prompt"], p["chosen"], p["rejected"])
+        if k not in seen:
+            seen.add(k)
+            uniq.append(p)
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        for p in uniq:
+            f.write(json.dumps(p, ensure_ascii=False) + "\n")
+    by = collections.Counter(p["kind"] for p in uniq)
+    print(f"{len(uniq)} pairs -> {args.out}")
+    for k, v in sorted(by.items()):
+        print(f"  {k:18s} {v}")
+
+
+def _selfcheck():
+    rng = random.Random(0)
+    assert placeholder("touch notes.txt") == "touch path/to/file"
+    assert placeholder("mkdir newfolder") == "mkdir path/to/directory"
+    assert placeholder("cp notes.txt Documents/") == "cp path/to/file path/to/directory"
+    assert placeholder("wget https://example.com/file.zip") is None
+    assert placeholder("ls -la") is None
+    assert placeholder("ping -c 1 192.168.1.10") is None
+    assert placeholder("curl ifconfig.me") is None
+    assert placeholder("sudo useradd -m ali") is None
+    assert tool_swap("touch newfile.txt", rng) == "fossil add newfile.txt"
+    assert tool_swap("sudo useradd -m newuser", rng) == "kcadm.sh create users -m newuser"
+    assert tool_swap("<Ctrl x>", rng) is None
+    assert split_tool("sudo apt install git") == ("sudo ", "apt", ["install", "git"])
+
+
+if __name__ == "__main__":
+    _selfcheck()
+    main()

--- a/training/probe.py
+++ b/training/probe.py
@@ -546,7 +546,13 @@ HOMOGRAPH = [
 ]
 
 
+RETRIEVE = 0  # --retrieve K: prepend K tldr lines (retrieve.py) to the user turn
+
+
 def chatml(q):
+    if RETRIEVE:
+        import retrieve
+        q = retrieve.prefix(q, RETRIEVE) + q
     return (f"<|im_start|>system\n{SYSTEM}<|im_end|>\n"
             f"<|im_start|>user\n{q}<|im_end|>\n<|im_start|>assistant\n")
 
@@ -584,6 +590,8 @@ def main():
     ap.add_argument("--server", default=PINNED if os.path.exists(PINNED) else "llama-server")
     ap.add_argument("--threads", type=int, default=4)
     ap.add_argument("--out", default="out/probe.jsonl")
+    ap.add_argument("--retrieve", type=int, default=0, metavar="K",
+                    help="prepend top-K tldr lines to the user turn (issue #55)")
     ap.add_argument("--rescore", metavar="JSONL",
                     help="re-apply the current regexes to a saved run; no server")
     args = ap.parse_args()
@@ -614,6 +622,12 @@ def main():
         return
 
     proc = boot(args.server, args.model, args.threads)
+    global RETRIEVE
+    RETRIEVE = args.retrieve
+    emb = None
+    if RETRIEVE:
+        import retrieve
+        emb = retrieve.serve()
     rows = []
     try:
         for t in TASKS:
@@ -633,6 +647,8 @@ def main():
     finally:
         proc.send_signal(signal.SIGTERM)
         proc.wait(timeout=30)
+        if emb:
+            emb.terminate()
 
     os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
     with open(args.out, "w") as f:

--- a/training/rebuild.sh
+++ b/training/rebuild.sh
@@ -5,8 +5,14 @@
 #
 # One variable per run, seed 42 (train.py). Third arg picks the train.py base
 # (default qwen, the incumbent), fourth the seed (issue #57: repeat a run
-# under seeds 43/44 to measure the noise floor). Read RESULTS.md before starting one:
-# the hypothesis goes there first, as something that could come back false.
+# under seeds 43/44 to measure the noise floor). Third arg `dpo` runs dpo.py
+# instead with the second arg as the pairs file (issue #56):
+#
+#   setsid nohup ./rebuild.sh qwen-v5-dpo out/dpo_pairs.jsonl dpo > out/rebuild-qwen-v5-dpo.log 2>&1 &
+#   DPO_BASE=out/X-lora-merged ./rebuild.sh X-dpo out/dpo_pairs.jsonl dpo   # on top of another SFT run
+#
+# Read RESULTS.md before starting one: the hypothesis goes there first, as
+# something that could come back false.
 set -euo pipefail
 cd "$(dirname "$0")"
 export PATH="$HOME/.local/bin:$PATH"
@@ -17,8 +23,12 @@ SEED=${4:-42}
 rm -f "out/REBUILD_DONE_$NAME"
 status() { echo "rebuild[$NAME]: $*"; }
 
-status "train (1 epoch, seed $SEED, $(wc -l <"$POOL") rows)"
-uv run train.py --base "$BASE" --seed "$SEED" --epochs 1 --data "$POOL" --out "out/$NAME-lora" || { echo "DONE rebuild:train-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }
+status "train (1 epoch, seed $SEED, $(wc -l <"$POOL") rows, base $BASE)"
+if [ "$BASE" = dpo ]; then
+  uv run dpo.py --base-ckpt "${DPO_BASE:-out/qwen-v5-lora-merged}" --data "$POOL" --out "out/$NAME-lora"
+else
+  uv run train.py --base "$BASE" --seed "$SEED" --epochs 1 --data "$POOL" --out "out/$NAME-lora"
+fi || { echo "DONE rebuild:train-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }
 
 status "convert + quantize + generate en/bm answers"
 ./finish.sh "out/$NAME-lora-merged" "$NAME" || { echo "DONE rebuild:convert-failed" >"out/REBUILD_DONE_$NAME"; exit 1; }

--- a/training/retrieve.py
+++ b/training/retrieve.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Cosine top-k over tldr one-liners (issue #55).
+
+  python3 retrieve.py                        # builds out/tldr_index.npz if missing
+  python3 retrieve.py "nak convert heic ke jpg"
+
+Index: dataset/raw/tldr.csv (nl, bash), deduped, description embedded with
+the bge-small GGUF served by the pinned llama-server on EMB_PORT. Lines are
+`description: command`, the shape prepended to the user turn as `Examples:`.
+"""
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TLDR = os.path.join(HERE, "..", "dataset", "raw", "tldr.csv")
+INDEX = os.path.join(HERE, "out", "tldr_index.npz")
+EMB_MODEL = os.path.join(HERE, "out", "bge-small-en-v1.5-f16.gguf")
+PINNED = os.path.expanduser("~/.cache/camne/bin/llama-b10333/llama-server")
+EMB_PORT = 18098
+
+
+def serve():
+    """Start the embedding server if nothing answers on EMB_PORT."""
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{EMB_PORT}/health", timeout=1)
+        return None
+    except Exception:
+        pass
+    p = subprocess.Popen([PINNED, "-m", EMB_MODEL, "--embeddings", "--pooling", "cls",
+                          "-c", "512", "-b", "512", "-ub", "512", "-t", "4", "-ngl", "0",
+                          "--no-webui", "--port", str(EMB_PORT)],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    t0 = time.monotonic()
+    while True:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{EMB_PORT}/health", timeout=1)
+            return p
+        except Exception:
+            if time.monotonic() - t0 > 60:
+                raise RuntimeError("embedding server never became ready")
+            time.sleep(0.2)
+
+
+def embed(texts):
+    req = urllib.request.Request(f"http://127.0.0.1:{EMB_PORT}/v1/embeddings",
+                                 data=json.dumps({"input": texts}).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=600) as r:
+        d = json.load(r)["data"]
+    v = np.array([e["embedding"] for e in sorted(d, key=lambda e: e["index"])], dtype=np.float32)
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+def build():
+    seen, lines, descs = set(), [], []
+    for r in csv.DictReader(open(TLDR, encoding="utf-8")):
+        key = (r["nl"], r["bash"])
+        if key in seen or not r["nl"] or not r["bash"]:
+            continue
+        seen.add(key)
+        lines.append(f"{r['nl']}: {r['bash']}")
+        descs.append(r["nl"])
+    vecs = np.concatenate([embed(descs[i:i + 256]) for i in range(0, len(descs), 256)])
+    np.savez(INDEX, vecs=vecs.astype(np.float16), lines=np.array(lines))
+    return vecs, lines
+
+
+_IDX = None
+
+
+def load():
+    global _IDX
+    if _IDX is None:
+        if not os.path.exists(INDEX):
+            build()
+        z = np.load(INDEX)
+        _IDX = (z["vecs"].astype(np.float32), list(z["lines"]))
+    return _IDX
+
+
+def top(query, k=3):
+    vecs, lines = load()
+    q = embed([query])[0]
+    best = np.argsort(vecs @ q)[::-1][:k]
+    return [lines[i] for i in best]
+
+
+def prefix(query, k=3):
+    return "Examples:\n" + "\n".join(top(query, k)) + "\nRequest: "
+
+
+if __name__ == "__main__":
+    p = serve()
+    try:
+        t0 = time.monotonic()
+        vecs, lines = load()
+        print(f"{len(lines)} lines, {os.path.getsize(INDEX) / 1e6:.1f} MB index, "
+              f"loaded in {time.monotonic() - t0:.1f}s")
+        for q in sys.argv[1:] or ["nak convert heic ke jpg", "nak tengok certificate expiry",
+                                  "convert heic to jpg", "check ssl certificate expiry",
+                                  "nak buat file baru", "empty the file app.log without deleting it"]:
+            t0 = time.monotonic()
+            hits = top(q)
+            print(f"\n{q}  ({(time.monotonic() - t0) * 1000:.0f} ms)")
+            for h in hits:
+                print("  " + h)
+    finally:
+        if p:
+            p.terminate()


### PR DESCRIPTION
Lands the rest of the stack that #58 started. #59, #60 and #61 merged into their stacked bases before GitHub retargeted them, so this PR carries their content to main unchanged: `dataset/prior.py` + pool_v7 and run 9 (#54), `dpo_pairs.py`/`dpo.py`/`rebuild.sh dpo` and both DPO arms (#56), the retrieval bench and its negative result (#55). Numbers and hypotheses in RESULTS.md, one section each; nothing here changes the shipped model.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)