### PR TITLE
Publish the four-register pool on HF with a NOTICE (#49)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,12 +5,18 @@ the License at http://www.apache.org/licenses/LICENSE-2.0
 
 ---
 
-Training data sources, by share of the NL->command pair pool:
+Training data sources, by measured share of the 228,357-row pool
+(dataset/NOTICE has the full table and the per-row source key):
 
-  58.2%  NL2SH-ALFA training split   MIT
+  48.2%  NL2SH-ALFA training split   MIT
          https://huggingface.co/datasets/westenfelder/NL2SH-ALFA
-  41.8%  tldr-pages                  CC-BY-4.0
+  29.2%  tldr-pages                  CC-BY-4.0
          https://github.com/tldr-pages/tldr
+  18.5%  cli-commands-explained      CC0-1.0    (declared, unverified)
+         https://huggingface.co/datasets/b-mc2/cli-commands-explained
+   3.0%  git-instruction-dataset     MIT        (declared, unverified)
+         https://huggingface.co/datasets/0xrushi/git-instruction-dataset
+   1.1%  hand-written basics rows    Apache-2.0 (this repository)
 
 Attribution, required by CC-BY-4.0: this work includes content from
 tldr-pages (https://github.com/tldr-pages/tldr) under CC-BY-4.0

--- a/dataset/CARD.md
+++ b/dataset/CARD.md
@@ -1,0 +1,93 @@
+---
+license: apache-2.0
+license_name: apache-2.0-with-source-notices
+license_link: NOTICE
+language:
+  - ms
+  - en
+task_categories:
+  - text-generation
+tags:
+  - bash
+  - shell
+  - nl2sh
+  - bahasa-melayu
+size_categories:
+  - 100K<n<1M
+pretty_name: camne four-register pool
+---
+
+# camne-pool
+
+Natural-language request in, one shell command out, with the request in four
+registers: formal Bahasa Melayu, colloquial Malay, rojak (Malay-English
+mix), English. This is the training pool behind
+[camne](https://github.com/opariffazman/camne) and the shipped model
+[opariffazman/camne-1.5b-Q4_K_M](https://huggingface.co/opariffazman/camne-1.5b-Q4_K_M).
+Numbers for every run are in the repo's
+[RESULTS.md](https://github.com/opariffazman/camne/blob/main/RESULTS.md).
+
+## Files
+
+| file | rows | what |
+|---|---|---|
+| `pool_v7.jsonl` | 228,357 | the pool camne v0.9.0 was trained on |
+| `basics.jsonl` | 2,581 | hand-written beginner tasks, already inside pool_v7 |
+| `eval_bm_300.jsonl` | 300 | InterCode-ALFA test prompts, colloquial Malay |
+| `eval_rojak_300.jsonl` | 300 | InterCode-ALFA test prompts, rojak |
+
+The two eval files are for measurement only. Do not train on them. They
+carry the ALFA gold command in `cmd` (the same gold the public ALFA scorer
+uses), so a model that has seen them is not measurable with ALFA anymore.
+
+## Row schema
+
+```json
+{"id": "nl2sh_train:21667", "register": "colloquial", "nl": "nak tengok file kat sini yang lebih besar dari 10KB je", "cmd": "find . -size +10k"}
+```
+
+`register` is one of `formal`, `colloquial`, `rojak`, `english`. The `id`
+prefix names the source (see NOTICE). One example row per register, taken
+from the pool as-is:
+
+```json
+{"id": "nl2sh_train:7", "register": "formal",     "nl": "Mengetahui pengguna yang sedang log masuk ke dalam sistem", "cmd": "who"}
+{"id": "nl2sh_train:7", "register": "colloquial", "nl": "nak tengok user login kat sini?",                             "cmd": "who"}
+{"id": "nl2sh_train:7", "register": "rojak",      "nl": "check siapa dah login je",                                    "cmd": "who"}
+{"id": "nl2sh_train:7", "register": "english",    "nl": "who is currently logged into the system",                     "cmd": "who"}
+```
+
+## Commands are never translated
+
+`cmd` is byte-identical to the source dataset for 225,143 of 228,357 rows.
+The rest are 2,581 hand-written rows (no upstream source) and 633 rows
+where a `path/to/...` placeholder was replaced by a concrete name on both
+sides of the pair (`prior.py`, issue #54); the placeholder token is the only
+diff. Technical nouns (file, folder, delete, download, server, ...) are kept
+English in the Malay text on purpose: that is how Malaysians type them.
+
+## How the pool is built
+
+Stdlib-only Python, in `dataset/` of the repo:
+
+1. `fetch.py`, `tldr.py`, `extra_sources.py`: pull the sources into `raw/*.csv`.
+2. `registers.py`: for each English pair, a local Gemma-SEA-LION-v3-9B-IT
+   endpoint writes the formal, colloquial and rojak versions of the request.
+   No external API; nothing leaves the machine.
+3. `stoplist.py`: force technical nouns back to English, strip particles.
+   `verify.py` asserts every command byte-identical to its source.
+4. `disambiguate.py`, `augment_verbs.py`, `rebalance.py`: name the tool where
+   one prompt maps to many commands, fill in Malay verbs the translator never
+   used, fix the tool-frequency inversion.
+5. `basics.py`: `basics.txt` (hand-written beginner tasks) to `basics.jsonl`.
+6. `prior.py`: drop or rewrite placeholder rows, cap the long tail at 300
+   rows per tool, cut `find` to 5%. Output is `pool_v7.jsonl`.
+
+## Sources and licence
+
+Apache-2.0 for the pool as a whole; each source keeps its own licence. By
+measured share of pool_v7: NL2SH-ALFA 48.2% (MIT), tldr-pages 29.2%
+(CC-BY-4.0), cli-commands-explained 18.5% (CC0-1.0), git-instruction-dataset
+3.0% (MIT), hand-written 1.1% (Apache-2.0). The Malay text is the output of
+Gemma-SEA-LION-v3-9B-IT (Gemma Terms of Use govern the model, not its
+outputs). Full table, links and the CC-BY attribution: [NOTICE](NOTICE).

--- a/dataset/CARD.md
+++ b/dataset/CARD.md
@@ -1,7 +1,5 @@
 ---
 license: apache-2.0
-license_name: apache-2.0-with-source-notices
-license_link: NOTICE
 language:
   - ms
   - en
@@ -22,10 +20,10 @@ pretty_name: camne four-register pool
 Natural-language request in, one shell command out, with the request in four
 registers: formal Bahasa Melayu, colloquial Malay, rojak (Malay-English
 mix), English. This is the training pool behind
-[camne](https://github.com/opariffazman/camne) and the shipped model
+[camne](https://github.com/officialdad/camne) and the shipped model
 [opariffazman/camne-1.5b-Q4_K_M](https://huggingface.co/opariffazman/camne-1.5b-Q4_K_M).
 Numbers for every run are in the repo's
-[RESULTS.md](https://github.com/opariffazman/camne/blob/main/RESULTS.md).
+[RESULTS.md](https://github.com/officialdad/camne/blob/main/RESULTS.md).
 
 ## Files
 

--- a/dataset/NOTICE
+++ b/dataset/NOTICE
@@ -1,0 +1,42 @@
+camne four-register pool
+Copyright 2026 Ariff Azman
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+Training data, by measured share of the 228,357-row pool_v7 (the pool
+camne v0.9.0 shipped on; pool_v8 = pool_v7 + 11,676 hand-written head rows,
+240,033 rows, same sources plus 4.9% hand-written):
+
+  48.2%  NL2SH-ALFA training split   MIT        verified (HF license field)
+         https://huggingface.co/datasets/westenfelder/NL2SH-ALFA
+  29.2%  tldr-pages                  CC-BY-4.0  verified (repo LICENSE.md)
+         https://github.com/tldr-pages/tldr
+  18.5%  cli-commands-explained      CC0-1.0    declared, unverified
+         (commandlinefu.com submissions via b-mc2/cli-commands-explained)
+         https://huggingface.co/datasets/b-mc2/cli-commands-explained
+   3.0%  git-instruction-dataset     MIT        declared, unverified
+         https://huggingface.co/datasets/0xrushi/git-instruction-dataset
+   1.1%  hand-written basics rows    Apache-2.0 (this repository, dataset/basics.txt)
+
+Every row's `id` names its source (`nl2sh_train:`, `tldr:`, `extra:`,
+`basics:`, `head:`); `extra:` indices below 14722 are cli-commands-explained,
+the rest git-instruction-dataset.
+
+Attribution, required by CC-BY-4.0: this work includes content from
+tldr-pages (https://github.com/tldr-pages/tldr) under CC-BY-4.0
+(https://creativecommons.org/licenses/by/4.0/). Page content is CC-BY-4.0;
+only that repository's scripts/ directory is MIT.
+
+The natural-language side of every sourced pair was machine-translated into
+Bahasa Melayu (formal, colloquial and rojak registers) with
+Gemma-SEA-LION-v3-9B-IT (https://huggingface.co/aisingapore/Gemma-SEA-LION-v3-9B-IT),
+run locally, no external API. That model is distributed under the Gemma
+Terms of Use (https://ai.google.dev/gemma/terms); the terms govern the model
+weights, not the Malay text it produced. Only the outputs are in this pool.
+
+Commands are byte-identical to their source and were never translated,
+except 633 rows in pool_v7 whose `path/to/...` placeholder was replaced by
+a concrete name on both sides of the pair (dataset/prior.py, issue #54).

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -163,6 +163,12 @@ Three things vary and the pool flattens all of them:
 
 ### Sources, licensing
 
+Pool sources, measured shares and licences: [`NOTICE`](NOTICE). The pool
+itself (pool_v7, basics, both eval sets, dataset card) is published at
+https://huggingface.co/datasets/opariffazman/camne-pool.
+
+Future colloquial-input sources:
+
 - Direct solicitation: [`survey.md`](survey.md). Own the data; no licence issue.
 - [Malaya](https://github.com/mesolitica/malaya) datasets — MIT/CC mixed;
   check per-set before ingesting. Useful for the shortcut lexicon.


### PR DESCRIPTION
Closes #49.

Dataset is live at https://huggingface.co/datasets/opariffazman/camne-pool: `pool_v7.jsonl` (the v0.9.0 pool, 228,357 rows), `basics.jsonl`, both ALFA eval sets (with gold, marked do-not-train), NOTICE, card.

In the repo: `dataset/NOTICE` (measured shares — NL2SH-ALFA 48.2% MIT, tldr 29.2% CC-BY-4.0 with attribution, cli-commands-explained 18.5% CC0 declared, git-instruction 3.0% MIT declared, basics 1.1%; SEA-LION outputs-only paragraph), `dataset/CARD.md` (the HF card source), root NOTICE share table refreshed to match, dataset/README.md points at both. The `target` field question was closed as "out" in a separate commit on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)