### PR TITLE
Runs 10 and 11: head rows and list-placeholder drop, neither ships (#62)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1175,3 +1175,144 @@ exist in `eval_gen.py` and is not being added for a result this clear.
 (multilingual embedder + retrieval-aware training rows, if ever) starts
 from the measurement instead of the idea. Index file (`out/tldr_index.npz`)
 and the bge GGUF are build artifacts, not committed.
+
+
+## Run 10: head rows for the beginner verbs (issue #62)
+
+**Hypothesis, written before the run.** Run 9 fixed `create file/folder/
+user` by cutting the tail, and the share it freed went to whatever was
+left uncapped: `git` 4.3% → 5.8% of the pool, and `delete file` came back
+`git obliterate`, `list processes` `pm2`, `edit file` `less`. v7-dpo
+flipped those exact misses back and moved nothing else, which is what
+three minutes of preference tuning on 40 real pairs can do. The prior is
+set by the SFT pool, so this run grows the head instead of trimming the
+tail again: `pool_v8 = pool_v7 + 11,676 rows` for the beginner verbs that
+have fewer than 1,000 real rows (`nano` 52, `less` 87, `unzip` 106, `zip`
+125, `scp` 137, … `ps` 769, `rm` 758 once augment_verbs duplicates are not
+counted). Prediction: on the probe, `delete file` (2/6 on run 9), `list
+processes` (0/4), `edit file` and `change permission` return to run 7's
+level or better with `rm` / `ps` / `nano` / `chmod` as the tool, with no
+placeholder regression (run 9 had 6 placeholder answers of 222; ≤ 6
+here); `create file/folder/user` hold 9/9, 8/8, 5/5; ALFA stays inside run
+9's CI on every register (BM 0.513, rojak 0.517, EN 0.563, ± ~0.055).
+Falsified if the four probe tasks do not move — then 1,000 rows per tool
+is not what sets the prior against 13k `git` rows and the next variable is
+share, not count — or if any ALFA register drops with p < 0.05, which would
+mean 12k templated rows are teaching the templates rather than the verbs.
+Then DPO on top with pairs rebuilt from this run's probe (`qwen-v8-dpo`),
+comparison row this run, same reading rule as arm B of #56.
+
+One variable vs run 9: the pool. Same recipe, seed 42, 1 epoch, probe
+prompts unchanged, none verbatim in basics.txt or basics_head.txt (probe.py
+now checks both at startup).
+
+**Where the rows come from (`dataset/head.py`, `dataset/basics_head.txt`).**
+Re-admitting real rows was the first choice and there is nothing to
+re-admit: the rows prior.py dropped for these tools are tldr placeholders
+whose NL never names the file (`Remove specific files` → `rm path/to/file1
+path/to/file2`), and the rows disambiguate.py dropped earlier are
+same-prompt pipe one-liners (`ps -ef |grep oracle |grep pmon |awk …`), 0 to
+164 per tool. So the head is written the way basics.txt was, in a new file
+so basics.txt's phrasings stay what probe.py's "not in training data" claim
+was made against: 118 blocks, four registers, plus slots — `{f}` file,
+`{t}` text file, `{d}` folder, `{u}` user, `{h}` host, `{n}` count, `{pid}`,
+`{p}` process, `{z}` zip, `{url}`, `{port}`, `{sshport}`, `{log}` — that
+head.py fills twenty ways from fixed lists, the k-th name of every list, so
+`rm {f}` / `nak buang fail {f}` is twenty consistent pairs. A phrasing must
+carry every slot its command carries (the parser refuses otherwise): a row
+whose NL never names what the command names is the placeholder bug again.
+18,568 rows expanded; budget per tool `min(918, 1000 − real rows)`, 918
+being `mkdir`'s row count in pool_v7 so no single tool jumps past the head
+it joins; whole tasks sampled with `prior.sample_ids`, seed 42. `chsh` is
+in the issue's list and gets nothing: it is a probe HOLDOUT tool, and a
+head row for it would un-hold it (head.py refuses HOLDOUT tools outright).
+
+| tool | pool_v7 | real | budget | added | **pool_v8** |
+|---|---|---|---|---|---|
+| nano | 53 | 52 | 918 | 918 | 971 |
+| less | 90 | 87 | 913 | 918 | 1,008 |
+| unzip | 174 | 106 | 894 | 904 | 1,078 |
+| zip | 197 | 125 | 875 | 876 | 1,073 |
+| scp | 164 | 137 | 863 | 864 | 1,028 |
+| head | 266 | 254 | 746 | 749 | 1,015 |
+| kill | 521 | 321 | 679 | 687 | 1,208 |
+| touch | 454 | 358 | 642 | 644 | 1,098 |
+| chown | 599 | 374 | 626 | 634 | 1,233 |
+| top | 168 | 159 | 841 | 570 | 738 |
+| chmod | 527 | 444 | 556 | 563 | 1,090 |
+| mv | 743 | 502 | 498 | 510 | 1,253 |
+| tail | 601 | 590 | 410 | 413 | 1,014 |
+| mkdir | 918 | 606 | 394 | 396 | 1,314 |
+| cp | 963 | 686 | 314 | 318 | 1,281 |
+| wget | 715 | 696 | 304 | 310 | 1,025 |
+| rm | 1,580 | 758 | 242 | 253 | 1,833 |
+| ssh | 806 | 757 | 243 | 249 | 1,055 |
+| ps | 880 | 769 | 231 | 238 | 1,118 |
+| df | 294 | 280 | 720 | 235 | 529 |
+| free | 87 | 82 | 918 | 221 | 308 |
+| du | 841 | 794 | 206 | 206 | 1,047 |
+| chsh | 16 | 16 | — | 0 | 16 |
+| cat / ls / grep / tar / curl / find | ≥ 1,000 real | | 0 | | unchanged |
+
+`top`, `df`, `free` land short of budget on purpose: they have three or
+four real command shapes (`free -h`, `df -h`, `top`) and no filename to
+vary, so the rows that exist are phrasings, not expansions; padding them
+to 900 would be the same sentence 900 times.
+
+| | pool_v7 (run 9) | **pool_v8** |
+|---|---|---|
+| rows | 228,357 | **240,033** (+5.1%) |
+| distinct first tokens | 4,102 | 4,102 |
+| top-30 share | 29.4% | 29.8% |
+| `git` share | 5.8% | 5.6% |
+| `find` share | 5.0% | 4.8% |
+| placeholders in cmd | 0 | 0 |
+| added, by register | | colloquial 3,761 / rojak 3,389 / english 2,965 / formal 1,561 |
+| added, by source | | re-admitted 0 / generated 11,676 |
+
+Every pool_v7 row is in pool_v8 in the same order with its command
+byte-identical (checked, 228,357/228,357); the 11,676 head rows match
+their block's command byte for byte; no `path/to`, no `<name>`; no head NL
+equals a probe prompt (one did — `kill the process using port 8080` at
+`{port}` = 8080 — and was reworded before the build).
+
+**Issue #51 rides along, two ways.** (a) 112 pool_v7 rows had the
+translator rename the file in the NL while the command kept it —
+`fail.txt` for `file.txt` (91), `fail1.csv`, `dokumen.zip` for
+`documents.zip`, `teks.txt`, `senarai.txt` for `list.txt`, `arkib.zip` —
+which is exactly the Malay-name → English-name mapping the issue reports
+the model learned. head.py restores the command's name in the NL where the
+command names one file the NL does not and the NL names one file whose
+stem is the Malay of it (a fixed nine-stem list; `build.xml` vs
+`buildfile.xml` is left alone). Commands untouched. (b) every slot list
+carries Malay filenames — `lama.txt`, `nota.txt`, `laporan.pdf`,
+`senarai.txt`, `gambar.jpg`, `projek`, `dokumen`, `tugasan` — byte-identical
+on both sides: 2,873 of the added rows, the positive example the pool never
+had. Not done: `grep -c lama.txt pool_v5` is 0, so the mapping in #51 was
+never a literal pair in the pool; it is the base model's translation prior
+plus the 112 rows, and (b) is what pushes against it. Measure with #51's
+four prompts exact after the run.
+
+**Hand-read, 200 of the added rows, `random.Random(42).sample`.** Registers
+read as intended and each row's NL names what its command names. What
+reads wrong, fixed before the build: `ssh -p 3306` / `scp -P 5432` — the
+port list is shared with `kill $(lsof -t -i:{port})`, where 3306 is
+right, so ssh/scp got their own `{sshport}` list; `tail -f data.csv` /
+`less +F main.py` — following a csv reads odd, so the follow blocks got a
+`{log}` list. Left as is, counted: slot lists are independent, so
+`zip -r resit.zip kuliah` and `unzip projek.zip -d gambar` pair unrelated
+names (consistent on both sides, just dull); `chmod 600 video.mp4` and
+`chmod u+w foto.png` are valid but not something anyone asks; two rojak
+phrasings are stiff (`chown -R arkib to farah`, `wget {url} resume`); the
+formal register is 13% of the added rows against 32% colloquial, the same
+skew basics.txt has (352 of 2,581). No Indonesian, no `lah`, no
+`Bagaimanakah`, no probe phrasing.
+
+**Measure.** Run 9 to beat on the probe (199/222, 6 placeholders, holdout
+33), run 7 for the tasks run 9 lost; ALFA vs run 9 paired, #57's error bar;
+`compare.py`, bench, #47 prompts exact, #51 prompts exact, placeholder
+rate. GPU commands, from the worktree's `training/`:
+`./rebuild.sh qwen-v8 ../dataset/out/pool_v8.jsonl`, then
+`python3 dpo_pairs.py --probe out/probe_qwen-v8.jsonl --out out/dpo_pairs_v8.jsonl`
+and `DPO_BASE=out/qwen-v8-lora-merged ./rebuild.sh qwen-v8-dpo out/dpo_pairs_v8.jsonl dpo`.
+Not started; hypothesis written first.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1349,7 +1349,7 @@ fail tu` (colloquial) and `nak delete file ni je` (rojak) — the exact
 beginner phrasing for `rm`, attached to a git-extras command. 253 head rows
 for `rm` cannot outvote a row whose NL *is* the probe prompt. prior.py's
 placeholder rule caught `path/to` and `<name>`; it did not catch the
-`file_1 file_2 ...` list shape, and pool_v8 still has 4,947 rows (2.1%)
+`file_1 file_2 ...` list shape, and pool_v8 still has 4,864 rows (2.0%)
 with `X1 X2 ...`, `argument1 argument2`, `filename`, `file_name`,
 `file_or_directory`, `directory_name` in the command — the tldr "list of
 things" idiom. Every one of those is a row where the NL is generic and the
@@ -1361,7 +1361,7 @@ went from five of six to none. Held-out `change shell` came back (0/3 →
 ±3-prompt churn the holdout always shows.
 
 **Run 11, hypothesis before the run.** `pool_v9` = `pool_v8` minus the
-4,947 list/name-placeholder rows (`dataset/lists.py`, one regex, whole
+4,864 list/name-placeholder rows (`dataset/lists.py`, one regex, whole
 pairs, commands otherwise untouched, count printed). One variable vs run
 10. Hypothesis: `delete file` returns to ≥ 5/6 with `rm`, no other probe
 task loses more than one phrasing, placeholders on the probe ≤ 2, ALFA

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1368,3 +1368,49 @@ task loses more than one phrasing, placeholders on the probe ≤ 2, ALFA
 inside run 10's CI on every register. Falsified if `delete file` stays
 below 5/6 — then the `git obliterate` habit is not that row and the
 head-rows idea needs a different lever (weight, not count).
+
+**Result (2026-08-17): falsified — the row was not the habit.** `qwen-v9`
+235,169 rows, then `qwen-v9-dpo` on its own probe misses.
+
+| register | shipped (v7-dpo) | v9 | v9-dpo | v9-dpo vs shipped, 95% CI | p |
+|---|---|---|---|---|---|
+| BM | 0.497 | 0.447 | 0.477 | −0.020 [−0.072, +0.032] | 0.53 |
+| rojak | 0.517 | 0.483 | 0.483 | −0.033 [−0.085, +0.019] | 0.26 |
+| EN | 0.543 | 0.533 | 0.543 | 0.000 [−0.053, +0.053] | 1 |
+
+v9's SFT BM of 0.447 was −0.050 vs the shipped model (p = 0.086) and DPO
+took back +0.030 (p = 0.09); both sit on the CI edge and neither clears it.
+Probe: v9 205, v9-dpo 204 (shipped 205); basics 168 → 171 (shipped 166);
+holdout 33 → **29** (shipped 34: `change shell` ×3 → `update-alternatives`,
+`whereis` → `git --exec-path`, `number lines` → `less -N`); placeholders 0
+on both. Bench 0.45 s warm at 4 threads, 1.61 GB RSS — RSS has crept
+1.49 → 1.56 → 1.61 across v7-dpo/v8/v9 for the same file size, which is
+either the box or something in `finish.sh` worth checking before the next
+ship.
+
+`delete file`: 1/6 (v9: `clido --remove file_name`, `echo $(ls -1 | sort
+-R | head -n 1)`) → 2/6 (v9-dpo: `coreutils rm file`, `clido --remove
+name`). Removing `git obliterate` moved the miss to the next obscure tool,
+not to `rm`. The reason is in the pool, and it is #47 again: the six probe
+phrasings are unnamed — `nak buang file ni`, `nak padam file ni`, `delete a
+file`, `Hapuskan file tersebut`. In pool_v9 the NL "delete/buang/padam/
+hapus file/fail (ni/tu)" with no filename occurs four times: three rows
+answer `<Enter>`, one `pvesm [f|free] local:iso/...`, **zero `rm`**.
+Every one of the 253 head rows for `rm` and every basics row carries a
+filename. Run 8's unnamed rows fixed `create` and never got a `delete`
+twin, so an unnamed delete has nothing to imitate but noise, and each pool
+change reshuffles which noise wins. `list processes` 4/4, `edit file` 5/5,
+`change permission` 5/5 held from run 10 — the head rows keep what they
+name.
+
+Not shipping: no register better than v0.9.0, holdout down 5, one beginner
+task still broken. Two runs (four models) on this thread say the same
+thing three ways: the pool fixes exactly the phrasing it contains, ALFA
+cannot see any of it, and each 4 h run trades one probe task for another
+inside the noise. Next, if anything: unnamed `delete`/`copy`/`move`/`edit`
+rows in the #47 shape (`nak buang file ni` → `rm file.txt`), plus a drop
+rule for rows whose NL is a bare beginner verb and whose command is not a
+core tool (`<Enter>`, `pvesm`), bundled with the next change that has an
+ALFA-sized reason to retrain — not on their own. `dataset/lists.py` stays
+(4,864 unrunnable rows out is right regardless), pool_v9 is the pool the
+next run starts from.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1316,3 +1316,55 @@ rate. GPU commands, from the worktree's `training/`:
 `python3 dpo_pairs.py --probe out/probe_qwen-v8.jsonl --out out/dpo_pairs_v8.jsonl`
 and `DPO_BASE=out/qwen-v8-lora-merged ./rebuild.sh qwen-v8-dpo out/dpo_pairs_v8.jsonl dpo`.
 Not started; hypothesis written first.
+
+**Result (2026-08-17): the head rows fix what they name and one poisoned
+row breaks what they do not.** `qwen-v8` 240,033 rows, 2 h 50 min; then
+`qwen-v8-dpo` on its own probe misses (3,4xx pairs, 3 min).
+
+| register | run 7 | v7-dpo (shipped) | v8 | v8-dpo | v8-dpo vs shipped, 95% CI | p |
+|---|---|---|---|---|---|---|
+| BM | 0.487 | 0.497 | 0.493 | 0.497 | 0.000 [−0.052, +0.052] | 1 |
+| rojak | 0.490 | 0.517 | 0.477 | 0.497 | −0.020 [−0.071, +0.031] | 0.52 |
+| EN | 0.543 | 0.543 | 0.530 | 0.530 | −0.013 [−0.066, +0.039] | 0.71 |
+
+Inside every CI, as expected by now. Probe: v8 206 / 222, v8-dpo 205 (the
+shipped model: 205); basics 169 → 168 (shipped 166); holdout 33 (shipped
+34); placeholders 5 → 3 (shipped 2). Bench 0.37–0.44 s warm at 4 threads,
+1.56–1.58 GB RSS (up ~70 MB from 1.49; within constraint 3, worth a second
+look before any ship).
+
+What the head rows bought, on the tasks they were written for: `edit file`
+3/5 → 5/5 (`nano readme.txt` on every phrasing), `change permission`
+2/5 → 5/5 (`chmod 644 file`, `chmod +x filename` — `icacls` gone),
+`list processes` 2/4 → 3/4 (`ps aux`; one `jobs` left), `ram usage/formal`
+`smem --mem` → `free -h`. Hypothesis held there.
+
+What broke: `delete file` 5/6 → 1/6 (v8) → **0/6** (v8-dpo). v8 says
+`git obliterate file_1 file_2 ...` on four phrasings; DPO, shown that as a
+rejected row, moves to `delete .file_name` and `touch /tmp/foo.txt && echo
+"Deleting /tmp/foo.txt"` — anywhere but `rm`. The cause is one tldr row,
+not the prior: `git obliterate file_1 file_2 ...` carries the description
+"Erase the existence of specific files", which SEA-LION rendered as `buang
+fail tu` (colloquial) and `nak delete file ni je` (rojak) — the exact
+beginner phrasing for `rm`, attached to a git-extras command. 253 head rows
+for `rm` cannot outvote a row whose NL *is* the probe prompt. prior.py's
+placeholder rule caught `path/to` and `<name>`; it did not catch the
+`file_1 file_2 ...` list shape, and pool_v8 still has 4,947 rows (2.1%)
+with `X1 X2 ...`, `argument1 argument2`, `filename`, `file_name`,
+`file_or_directory`, `directory_name` in the command — the tldr "list of
+things" idiom. Every one of those is a row where the NL is generic and the
+command is not runnable.
+
+Not shipping: same ALFA, same probe total as v0.9.0, and a beginner task
+went from five of six to none. Held-out `change shell` came back (0/3 →
+3/3, `chsh -s zsh`) and `reverse lines` went (3/3 → 0/3), which is the
+±3-prompt churn the holdout always shows.
+
+**Run 11, hypothesis before the run.** `pool_v9` = `pool_v8` minus the
+4,947 list/name-placeholder rows (`dataset/lists.py`, one regex, whole
+pairs, commands otherwise untouched, count printed). One variable vs run
+10. Hypothesis: `delete file` returns to ≥ 5/6 with `rm`, no other probe
+task loses more than one phrasing, placeholders on the probe ≤ 2, ALFA
+inside run 10's CI on every register. Falsified if `delete file` stays
+below 5/6 — then the `git obliterate` habit is not that row and the
+head-rows idea needs a different lever (weight, not count).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1214,7 +1214,7 @@ path/to/file2`), and the rows disambiguate.py dropped earlier are
 same-prompt pipe one-liners (`ps -ef |grep oracle |grep pmon |awk …`), 0 to
 164 per tool. So the head is written the way basics.txt was, in a new file
 so basics.txt's phrasings stay what probe.py's "not in training data" claim
-was made against: 118 blocks, four registers, plus slots — `{f}` file,
+was made against: 107 blocks, four registers, plus slots — `{f}` file,
 `{t}` text file, `{d}` folder, `{u}` user, `{h}` host, `{n}` count, `{pid}`,
 `{p}` process, `{z}` zip, `{url}`, `{port}`, `{sshport}`, `{log}` — that
 head.py fills twenty ways from fixed lists, the k-th name of every list, so

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -27,6 +27,8 @@ prior.py          # pool_v6 (= pool_v4.bal + basics) → out/pool_v7.jsonl
 head.py           # pool_v7 + basics_head.txt → out/pool_v8.jsonl  head rows
                   # for beginner verbs under 1,000 real rows, slots filled
                   # 20 ways; restores translated filenames in NL (#62, #51)
+lists.py          # pool_v8 → out/pool_v9.jsonl  drop tldr's `file1 file2 ...`
+                  # / `filename` list-placeholder rows (issue #62, run 11)
 ```
 
 Full rebuild from raw, no GPU:

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -24,6 +24,9 @@ basics.py         # basics.txt → out/basics.jsonl  hand-written beginner rows
 prior.py          # pool_v6 (= pool_v4.bal + basics) → out/pool_v7.jsonl
                   # drop/rewrite path/to placeholders, cap the long tail at
                   # 300, find to 5% (issue #54)
+head.py           # pool_v7 + basics_head.txt → out/pool_v8.jsonl  head rows
+                  # for beginner verbs under 1,000 real rows, slots filled
+                  # 20 ways; restores translated filenames in NL (#62, #51)
 ```
 
 Full rebuild from raw, no GPU:

--- a/dataset/basics_head.txt
+++ b/dataset/basics_head.txt
@@ -1,0 +1,695 @@
+# Head rows for the beginner verbs (issue #62). Same block format as
+# basics.txt, read by head.py, plus slots that head.py fills twenty ways:
+#   {t} text file   {f} any file   {f2} another file   {d} folder   {d2} another
+#   {u} user  {h} host  {n} count  {pid} PID  {port}  {sshport}  {p} process
+#   {z} zip  {url}  {log} log file
+# A phrasing must carry every slot its cmd carries. No path/to. Probe
+# prompts (training/probe.py) are not here; HOLDOUT tools are refused.
+# Slot lists carry Malay filenames on purpose (issue #51): lama.txt stays
+# lama.txt on both sides.
+
+## --- nano ------------------------------------------------------------------
+
+cmd: nano {t}
+F: Buka fail {t} dalam editor nano | Sunting fail {t} menggunakan nano | Edit kandungan fail {t}
+C: nak edit fail {t} | buka {t} guna nano | tolong buka fail {t} nak ubah sikit | nak ubah isi fail {t} | edit {t} sekejap | boleh tak buka {t} untuk edit | nak tukar isi {t} | tlg buka fail {t} dalam nano
+R: nak edit file {t} dengan nano | open {t} in nano | edit file {t} | nak open {t} untuk edit | edit {t} guna nano
+E: edit {t} with nano | open {t} in nano | edit the file {t} | open {t} so I can change it
+
+cmd: nano {d}/{t}
+F: Buka fail {t} dalam direktori {d} menggunakan nano | Sunting fail {d}/{t}
+C: nak edit fail {t} dalam folder {d} | buka {d}/{t} guna nano | tolong buka {t} kat folder {d} untuk edit
+R: nak edit file {t} dalam folder {d} | open {d}/{t} in nano | edit {t} inside {d}
+E: edit {t} in the {d} folder with nano | open {d}/{t} in nano
+
+cmd: nano +{n} {t}
+F: Buka fail {t} dalam nano terus pada baris {n}
+C: nak buka {t} terus kat baris {n} | edit fail {t} mula dari baris {n} | buka {t} guna nano, terus lompat ke baris {n}
+R: nak open {t} in nano at line {n} | edit {t} terus jump ke line {n}
+E: open {t} in nano at line {n} | edit {t} starting at line {n}
+
+cmd: nano -l {t}
+F: Buka fail {t} dalam nano dengan nombor baris dipaparkan
+C: nak edit {t} dengan nombor baris sekali | buka {t} guna nano tunjuk nombor baris
+R: nak edit {t} in nano with line numbers | open {t} nano show line number
+E: edit {t} in nano showing line numbers | open {t} in nano with line numbers on
+
+cmd: sudo nano {t}
+F: Buka fail {t} dalam nano sebagai root | Sunting fail sistem {t} dengan kebenaran root
+C: nak edit fail {t} tapi kena guna sudo | buka {t} guna nano sebagai root | fail {t} tak boleh save, nak edit guna sudo
+R: nak edit {t} with sudo | open {t} in nano as root | sudo edit file {t}
+E: edit {t} as root with nano | open {t} in nano using sudo
+
+## --- less ------------------------------------------------------------------
+
+cmd: less {t}
+F: Buka fail {t} untuk dibaca muka surat demi muka surat | Paparkan fail {t} dalam pager | Baca kandungan {t} secara berskrol
+C: nak baca fail {t} sikit-sikit boleh scroll | buka {t} yang panjang tu | nak tengok isi {t} boleh scroll atas bawah | tolong buka {t} untuk baca je | nak baca {t} muka demi muka | tgk fail {t} boleh scroll | baca {t} tanpa edit
+R: nak baca file {t} page by page | open {t} boleh scroll | view {t} in pager | nak view file {t} je, tak nak edit | read {t} dalam less
+E: read {t} page by page | open {t} in a pager | view {t} without editing | scroll through {t}
+
+cmd: less {d}/{t}
+F: Baca fail {t} dalam direktori {d} muka surat demi muka surat
+C: nak baca {t} dalam folder {d} boleh scroll | buka fail {d}/{t} untuk baca je
+R: nak view file {t} dalam folder {d} | open {d}/{t} in pager
+E: read {d}/{t} page by page | view {t} in the {d} folder with a pager
+
+cmd: less -N {t}
+F: Baca fail {t} dengan nombor baris dipaparkan
+C: nak baca {t} dengan nombor baris sekali | buka {t} boleh scroll, tunjuk nombor baris
+R: nak view {t} with line numbers | read {t} in less show line number
+E: view {t} with line numbers | read {t} page by page showing line numbers
+
+cmd: less +F {log}
+F: Ikuti fail {log} secara langsung di dalam pager
+C: nak tengok {log} secara live tapi boleh scroll ke atas | follow fail {log} guna less
+R: nak follow file {log} in less | tail {log} live tapi boleh scroll
+E: follow {log} live inside less | watch {log} grow but keep scrolling
+
+cmd: less +G {t}
+F: Buka fail {t} dan terus ke penghujungnya
+C: nak buka {t} terus kat hujung fail | baca {t} mula dari bawah sekali
+R: nak open {t} terus jump to end | view {t} start from the bottom
+E: open {t} jumping straight to the end | view {t} starting at the last line
+
+cmd: less -S {t}
+F: Baca fail {t} tanpa membalut baris yang panjang
+C: nak baca {t} tapi jangan wrap baris panjang | buka {t} baris panjang jangan patah
+R: nak view {t} without line wrap | read {t} tapi long lines jangan wrap
+E: view {t} without wrapping long lines | read {t} with long lines cut off instead of wrapped
+
+## --- head ------------------------------------------------------------------
+
+cmd: head {t}
+F: Paparkan sepuluh baris pertama fail {t} | Tunjukkan bahagian awal fail {t}
+C: nak tengok baris awal fail {t} | tunjuk 10 baris pertama {t} | nak tengok permulaan {t} je | tgk atas sikit fail {t}
+R: nak tengok first few lines file {t} | show top of {t} | preview {t} atas sikit
+E: show the first lines of {t} | print the first 10 lines of {t} | peek at the top of {t}
+
+cmd: head -n {n} {t}
+F: Paparkan {n} baris pertama fail {t} | Tunjukkan {n} baris teratas {t}
+C: nak tengok {n} baris pertama {t} | tunjuk {n} baris awal fail {t} | bagi {n} baris atas {t} je | tgk {n} baris pertama dalam {t}
+R: nak tengok first {n} lines {t} | show {n} baris pertama file {t} | print top {n} lines of {t} | head {t} {n} lines je
+E: show the first {n} lines of {t} | print the top {n} lines of {t} | display {n} lines from the start of {t}
+
+cmd: head -n {n} {d}/{t}
+F: Paparkan {n} baris pertama fail {t} dalam direktori {d}
+C: nak tengok {n} baris pertama {t} dalam folder {d} | tunjuk {n} baris awal {d}/{t}
+R: nak tengok first {n} lines {d}/{t} | show top {n} lines of {t} dalam {d}
+E: show the first {n} lines of {d}/{t} | print the first {n} lines of {t} in {d}
+
+cmd: head -c {n} {t}
+F: Paparkan {n} bait pertama fail {t}
+C: nak tengok {n} bait pertama {t} | tunjuk {n} byte awal fail {t}
+R: nak tengok first {n} bytes {t} | show {n} bytes pertama file {t}
+E: show the first {n} bytes of {t} | print {n} bytes from the start of {t}
+
+cmd: head -n {n} *.txt
+F: Paparkan {n} baris pertama setiap fail .txt dalam direktori ini
+C: nak tengok {n} baris pertama semua fail txt kat sini | tunjuk {n} baris awal setiap fail .txt
+R: nak tengok first {n} lines semua file txt | show top {n} lines of every .txt kat sini
+E: show the first {n} lines of every .txt file here | print the top {n} lines of each txt file
+
+cmd: head -n -{n} {t}
+F: Paparkan fail {t} kecuali {n} baris terakhir
+C: nak tengok {t} tapi buang {n} baris hujung | tunjuk semua {t} kecuali {n} baris bawah
+R: nak print {t} except last {n} lines | show {t} tapi skip {n} baris terakhir
+E: print {t} except the last {n} lines | show all of {t} but the last {n} lines
+
+## --- tail ------------------------------------------------------------------
+
+cmd: tail {t}
+F: Paparkan sepuluh baris terakhir fail {t} | Tunjukkan penghujung fail {t}
+C: nak tengok baris akhir fail {t} | tunjuk hujung fail {t} | tgk bawah sikit {t} | nak tengok baris bawah {t} je
+R: nak tengok last few lines {t} | show bottom of file {t} | print hujung {t}
+E: show the last lines of {t} | print the end of {t} | show the bottom of {t}
+
+cmd: tail -n {n} {t}
+F: Paparkan {n} baris terakhir fail {t} | Tunjukkan {n} baris terbawah {t}
+C: nak tengok {n} baris terakhir {t} | tunjuk {n} baris hujung fail {t} | bagi {n} baris bawah {t} | tgk {n} baris akhir dalam {t}
+R: nak tengok last {n} lines {t} | show {n} baris terakhir file {t} | print bottom {n} lines of {t}
+E: show the last {n} lines of {t} | print the last {n} lines from {t} | display the final {n} lines of {t}
+
+cmd: tail -f {log}
+F: Ikuti fail {log} secara langsung apabila baris baharu ditambah | Paparkan {log} secara berterusan
+C: nak tengok {log} secara live, baris baru terus keluar | tunjuk {log} yang tengah jalan | nak monitor fail {log} masa dia update | tgk {log} live | follow fail {log}
+R: nak follow file {log} live | tengok {log} real time | monitor {log} as it grows | tail {log} live
+E: follow {log} as it grows | watch {log} live | keep printing new lines of {log} | tail {log} in real time
+
+cmd: tail -f {d}/{log}
+F: Ikuti fail {log} dalam direktori {d} secara langsung
+C: nak tengok {log} dalam folder {d} secara live | follow fail {d}/{log}
+R: nak follow {d}/{log} live | monitor {log} inside {d} real time
+E: follow {d}/{log} live | watch {log} in the {d} folder as it grows
+
+## --- rm --------------------------------------------------------------------
+
+cmd: rm {f}
+F: Padam fail {f} | Hapuskan fail {f} | Buang fail {f} daripada direktori ini
+C: nak buang fail {f} | tolong padam fail {f} | delete {f} | nak hapus fail {f} | buang {f} je | boleh tak padam {f} | tlg buang {f} | nak padam fail {f} ni | buang fail {f} dari sini
+R: nak delete file {f} | remove file {f} | tolong buang file {f} | nak padam file {f} | delete {f} please | remove {f} kat sini
+E: delete {f} | remove the file {f} | get rid of {f} | delete the file {f}
+
+cmd: rm -r {d}
+F: Padam direktori {d} beserta semua kandungannya | Hapuskan folder {d} dan isinya
+C: nak buang folder {d} dengan semua isi dia | padam folder {d} sekali dengan isi | tolong hapus folder {d} | buang folder {d} terus | nak padam direktori {d}
+R: nak delete folder {d} dengan semua isi | remove folder {d} and everything inside | buang folder {d} sekali | delete directory {d}
+E: delete the folder {d} and everything in it | remove the directory {d} recursively | delete the {d} folder
+
+cmd: rm {f} {f2}
+F: Padam fail {f} dan {f2} | Hapuskan dua fail {f} dan {f2}
+C: nak buang {f} dengan {f2} sekali | padam fail {f} dan {f2} | tolong delete {f} {f2}
+R: nak delete {f} and {f2} | remove file {f} dan {f2} sekali
+E: delete {f} and {f2} | remove the files {f} and {f2}
+
+## --- ps --------------------------------------------------------------------
+
+cmd: ps aux
+F: Paparkan senarai semua proses yang sedang berjalan | Senaraikan setiap proses pada sistem ini
+C: nak tengok semua proses yang tengah jalan | tunjuk semua program yang tengah run | apa proses yang jalan sekarang | senarai proses kat komputer ni | nak tengok proses semua sekali
+R: nak tengok semua process yang running | show all process | list every process kat sistem ni | apa process tengah jalan sekarang
+E: show all running processes | list every process on the system | what processes are running
+
+cmd: ps -ef
+F: Senaraikan semua proses dalam format penuh
+C: nak senarai semua proses format penuh | tunjuk semua proses dengan PID dan parent dia
+R: nak list all process full format | show semua process dengan PID
+E: list all processes in full format | show every process with its PID and parent
+
+cmd: ps aux | grep {p}
+F: Cari proses {p} dalam senarai proses | Semak sama ada {p} sedang berjalan
+C: nak tengok {p} tengah jalan ke tak | cari proses {p} | {p} ni ada jalan ke | tunjuk proses {p} je | nak check {p} running tak
+R: nak check {p} running ke tak | find {p} process | is {p} running | show process {p} je | list process {p}
+E: is {p} running | find the {p} process | show processes named {p} | check if {p} is running
+
+cmd: ps -u {u}
+F: Senaraikan proses milik pengguna {u}
+C: nak tengok proses user {u} je | tunjuk semua proses yang {u} tengah jalankan | proses apa yang {u} run
+R: nak list process user {u} | show process belonging to {u} | apa process yang {u} run
+E: list processes owned by {u} | show what user {u} is running | show {u}'s processes
+
+cmd: ps -p {pid}
+F: Paparkan maklumat proses dengan ID {pid}
+C: nak tengok proses PID {pid} tu apa | proses {pid} tu program apa | tunjuk info proses nombor {pid}
+R: nak check process {pid} apa | show process with PID {pid} | what is process {pid}
+E: show the process with PID {pid} | what is process {pid} | show info on process {pid}
+
+## --- chmod -----------------------------------------------------------------
+
+cmd: chmod +x setup.sh
+F: Jadikan fail setup.sh boleh dilaksanakan
+C: nak buat setup.sh boleh run | bagi permission execute kat setup.sh
+R: nak make setup.sh executable | bagi execute permission to setup.sh
+E: make setup.sh executable | give setup.sh execute permission
+
+cmd: chmod +x backup.sh
+F: Berikan kebenaran laksana kepada backup.sh
+C: nak buat backup.sh boleh dijalankan | bagi backup.sh permission untuk run
+R: nak make backup.sh executable | allow backup.sh to run
+E: make backup.sh executable | let backup.sh be executed
+
+cmd: chmod +x run.py
+F: Jadikan skrip run.py boleh dilaksanakan terus
+C: nak buat run.py boleh run terus | bagi permission execute kat run.py
+R: nak make run.py executable | chmod run.py boleh run
+E: make run.py executable | give run.py execute permission
+
+cmd: chmod 644 {f}
+F: Tetapkan kebenaran fail {f} kepada 644 | Jadikan {f} boleh dibaca semua tetapi ditulis oleh pemilik sahaja
+C: nak set permission {f} jadi 644 | buat {f} boleh baca semua orang tapi aku je boleh tulis | tukar permission fail {f} ke 644
+R: nak set permission {f} to 644 | make {f} readable by everyone, writable by me only | chmod 644 file {f}
+E: set {f} permissions to 644 | make {f} readable by all but writable only by me | chmod {f} to 644
+
+cmd: chmod 600 {f}
+F: Hadkan fail {f} supaya hanya pemilik boleh membaca dan menulis
+C: nak buat {f} aku je boleh baca | set permission {f} jadi private | orang lain jangan boleh baca {f}
+R: nak set {f} permission to 600 | make {f} private, owner only | lock file {f} untuk aku je
+E: make {f} readable only by me | set {f} permissions to 600 | keep {f} private to the owner
+
+cmd: chmod 755 {d}
+F: Tetapkan kebenaran direktori {d} kepada 755
+C: nak set permission folder {d} 755 | bagi folder {d} 755 | tukar permission direktori {d} jadi 755
+R: nak chmod 755 folder {d} | set folder {d} permission 755 | make folder {d} 755
+E: set the {d} folder permissions to 755 | chmod {d} to 755 | give the directory {d} 755
+
+cmd: chmod -R 755 {d}
+F: Tetapkan kebenaran 755 kepada direktori {d} dan semua kandungannya
+C: nak set permission 755 untuk folder {d} sekali dengan semua isi | tukar permission satu folder {d} | bagi 755 kat {d} dan semua dalam dia
+R: nak chmod 755 recursively folder {d} | set permission 755 for whole folder {d} | chmod -R {d} 755
+E: set 755 permissions on {d} and everything inside | recursively chmod {d} to 755 | apply 755 to the whole {d} tree
+
+cmd: chmod a+r {f}
+F: Benarkan semua pengguna membaca fail {f}
+C: nak bagi semua orang boleh baca {f} | buat {f} boleh dibaca sesiapa | bagi permission baca {f} kat semua
+R: nak make {f} readable by everyone | bagi semua orang read {f} | allow all users to read {f}
+E: let everyone read {f} | make {f} readable by all users | give everyone read permission on {f}
+
+cmd: chmod u+w {f}
+F: Berikan kebenaran tulis kepada pemilik fail {f}
+C: nak bagi aku boleh tulis {f} | fail {f} read only, nak buat boleh edit | tambah permission tulis kat {f}
+R: nak make {f} writable for me | add write permission to {f} | {f} read only, nak unlock
+E: give me write permission on {f} | make {f} writable by the owner | add write permission to {f}
+
+## --- chown -----------------------------------------------------------------
+
+cmd: chown {u} {f}
+F: Tukar pemilik fail {f} kepada pengguna {u} | Jadikan {u} pemilik fail {f}
+C: nak tukar owner {f} jadi {u} | buat {u} jadi pemilik fail {f} | tukar pemilik {f} ke {u}
+R: nak change owner file {f} to {u} | set owner {f} jadi {u} | chown {f} kepada {u}
+E: change the owner of {f} to {u} | make {u} own {f} | set {u} as the owner of {f}
+
+cmd: chown {u}:{u} {f}
+F: Tukar pemilik dan kumpulan fail {f} kepada {u}
+C: nak tukar owner dan group {f} jadi {u} | buat {f} milik {u} dengan group {u} sekali
+R: nak change owner and group of {f} to {u} | chown {f} to {u}:{u} | set owner dan group file {f} jadi {u}
+E: change the owner and group of {f} to {u} | make {u} the owner and group of {f}
+
+cmd: chown -R {u}:{u} {d}
+F: Tukar pemilik dan kumpulan direktori {d} beserta kandungannya kepada {u}
+C: nak tukar owner folder {d} dengan semua isi jadi {u} | buat satu folder {d} milik {u} | tukar pemilik semua dalam {d} ke {u}
+R: nak change owner folder {d} recursively to {u} | chown -R {d} to {u} | make {u} own whole folder {d}
+E: change the owner of {d} and everything in it to {u} | recursively chown {d} to {u} | make {u} own the whole {d} folder
+
+cmd: chown -R {u} {d}
+F: Tukar pemilik direktori {d} dan semua kandungannya kepada {u}
+C: nak {u} jadi owner folder {d} sekali dengan isi | tukar pemilik folder {d} ke {u}, isi dia sekali
+R: nak change owner of folder {d} to {u} recursively | set {u} as owner of {d} and everything inside
+E: make {u} the owner of {d} and all its contents | change the owner of the {d} tree to {u}
+
+cmd: sudo chown {u} {f}
+F: Tukar pemilik fail {f} kepada {u} dengan kebenaran root
+C: nak tukar owner {f} jadi {u} tapi kena sudo | fail {f} milik root, tukar owner ke {u}
+R: nak sudo chown {f} to {u} | change owner {f} to {u} with sudo
+E: change the owner of {f} to {u} using sudo | chown {f} to {u} as root
+
+cmd: sudo chown -R {u}:{u} {d}
+F: Tukar pemilik dan kumpulan direktori {d} kepada {u} sebagai root
+C: nak tukar owner folder {d} jadi {u} guna sudo, isi sekali | folder {d} kena root, tukar ke {u} semua
+R: nak sudo chown -R folder {d} to {u} | change owner of whole {d} to {u} as root
+E: change the owner and group of the whole {d} folder to {u} as root | sudo chown {d} recursively to {u}
+
+## --- cp --------------------------------------------------------------------
+
+cmd: cp {f} {d}/
+F: Salin fail {f} ke dalam direktori {d} | Letakkan salinan {f} dalam folder {d}
+C: nak salin {f} masuk folder {d} | copy fail {f} ke {d} | tolong salin {f} ke dalam {d} | buat salinan {f} kat folder {d}
+R: nak copy file {f} masuk folder {d} | copy {f} into {d} | duplicate {f} ke folder {d}
+E: copy {f} into the {d} folder | put a copy of {f} in {d} | copy the file {f} to {d}
+
+cmd: cp -r {d} {d2}
+F: Salin direktori {d} beserta kandungannya kepada {d2} | Buat salinan folder {d} bernama {d2}
+C: nak salin satu folder {d} jadi {d2} | copy folder {d} dengan semua isi dia ke {d2} | buat salinan folder {d} nama {d2} | tolong copy folder {d} jadi {d2}
+R: nak copy folder {d} to {d2} | copy whole folder {d} jadi {d2} | duplicate folder {d} as {d2}
+E: copy the folder {d} to {d2} | duplicate the folder {d} as {d2} | copy the directory {d} with everything inside to {d2}
+
+cmd: cp {f} {f}.bak
+F: Buat salinan sandaran fail {f} bernama {f}.bak
+C: nak buat backup {f} dulu sebelum ubah | salin {f} jadi {f}.bak | tolong backup fail {f}
+R: nak backup file {f} to {f}.bak | make a copy of {f} as {f}.bak | backup {f} dulu
+E: back up {f} as {f}.bak | make a backup copy of {f} | copy {f} to {f}.bak
+
+## --- mv --------------------------------------------------------------------
+
+cmd: mv {f} {d}/
+F: Pindahkan fail {f} ke dalam direktori {d} | Alihkan {f} ke folder {d}
+C: nak pindah fail {f} masuk folder {d} | alih {f} ke {d} | tolong move {f} ke folder {d} | letak {f} dalam folder {d} | pindahkan {f} masuk {d}
+R: nak move file {f} ke folder {d} | move {f} into {d} | pindah {f} to {d} | put {f} inside folder {d}
+E: move {f} into {d} | put {f} in the {d} folder | move the file {f} to {d}
+
+cmd: mv {d} {d2}
+F: Namakan semula direktori {d} sebagai {d2} | Tukar nama folder {d} kepada {d2}
+C: nak tukar nama folder {d} jadi {d2} | rename folder {d} ke {d2} | tolong tukar nama direktori {d} kepada {d2}
+R: nak rename folder {d} to {d2} | tukar nama folder {d} jadi {d2} | rename directory {d} as {d2}
+E: rename the folder {d} to {d2} | change the directory name {d} to {d2}
+
+cmd: mv {t} {t}.old
+F: Namakan semula fail {t} sebagai {t}.old
+C: nak tukar nama {t} jadi {t}.old | rename {t} ke {t}.old | tolong tambah .old kat nama {t}
+R: nak rename {t} to {t}.old | tukar nama file {t} jadi {t}.old
+E: rename {t} to {t}.old | add .old to the name of {t}
+
+cmd: mv {d}/{f} .
+F: Pindahkan fail {f} dari direktori {d} ke direktori semasa
+C: nak pindah {f} dari folder {d} ke sini | alih {d}/{f} keluar ke sini | ambil {f} dalam {d} bawa ke folder ni
+R: nak move {f} from {d} to here | move {d}/{f} ke current folder | pull {f} out of {d} to here
+E: move {f} out of {d} into the current folder | move {d}/{f} here | bring {f} from {d} to this folder
+
+## --- mkdir -----------------------------------------------------------------
+
+cmd: mkdir {d}
+F: Cipta satu direktori baharu bernama {d} | Wujudkan folder {d}
+C: nak buat folder baru nama {d} | tolong buat direktori {d} | buat folder {d} kat sini | nak cipta folder {d} | buat satu folder nama {d}
+R: nak create folder {d} | create new folder nama {d} | tolong buat folder {d} | make directory {d}
+E: create a new folder called {d} | make a directory named {d} | mkdir {d}
+
+cmd: mkdir -p {d}/{d2}
+F: Cipta direktori {d}/{d2} beserta direktori induk yang belum wujud
+C: nak buat folder {d2} dalam {d}, kalau {d} takde buat sekali | buat folder bersarang {d}/{d2} | tolong buat {d}/{d2} dengan folder atas dia sekali
+R: nak create folder {d}/{d2} dengan parent folder sekali | create nested folder {d}/{d2} | mkdir {d}/{d2} including parents
+E: create the nested folders {d}/{d2} | make {d}/{d2} including parent directories | create {d2} inside {d}, creating {d} if needed
+
+cmd: mkdir {d} {d2}
+F: Cipta dua direktori bernama {d} dan {d2}
+C: nak buat dua folder {d} dan {d2} | buat folder {d} {d2} sekali gus | tolong buat folder {d} dengan {d2}
+R: nak create 2 folder {d} {d2} | create folders {d} and {d2} sekali
+E: create two folders {d} and {d2} | make folders {d} and {d2} at once
+
+## --- touch -----------------------------------------------------------------
+
+cmd: touch {t}
+F: Cipta satu fail baharu bernama {t} | Wujudkan fail kosong {t}
+C: nak buat fail baru nama {t} | tolong buat fail {t} | buat file baru {t} | nak cipta fail {t} kat sini | buat fail kosong {t} | nak buat {t} baru
+R: nak create file baru {t} | create new file {t} kat sini | tolong buat file {t} | nak buat empty file {t}
+E: create a new file called {t} | make an empty file {t} | create {t}
+
+cmd: touch {f}
+F: Cipta fail kosong bernama {f}
+C: nak buat fail kosong nama {f} | buat fail {f} je, kosong pun takpe | tolong cipta fail {f}
+R: nak create empty file {f} | create file {f} | buat new file {f}
+E: create an empty file named {f} | make a new file {f}
+
+cmd: touch {d}/{t}
+F: Cipta fail baharu {t} di dalam direktori {d}
+C: nak buat fail {t} dalam folder {d} | buat fail baru {t} kat {d} | tolong cipta {d}/{t}
+R: nak create file {t} dalam folder {d} | create new file {t} inside {d} | buat file {d}/{t}
+E: create a new file {t} inside the {d} folder | make an empty file {d}/{t}
+
+cmd: touch {t} {f}
+F: Cipta dua fail baharu bernama {t} dan {f}
+C: nak buat dua fail {t} dan {f} | buat fail {t} dengan {f} sekali gus | tolong cipta {t} dan {f}
+R: nak create 2 file {t} {f} | create files {t} and {f} sekali
+E: create two files {t} and {f} | make the files {t} and {f} at once
+
+## --- df --------------------------------------------------------------------
+
+cmd: df -h {d}
+F: Paparkan ruang cakera yang masih kosong pada partition yang memuatkan direktori {d}
+C: nak tengok berapa banyak space tinggal kat partition folder {d} | folder {d} ni duduk kat disk yang tinggal berapa | tgk baki space untuk {d}
+R: nak check disk space for folder {d} | berapa free space kat partition {d} | disk usage untuk {d} punya partition
+E: how much disk space is left on the partition holding {d} | show free space for the filesystem of {d} | check disk space where {d} lives
+
+cmd: df -h /home
+F: Paparkan ruang cakera yang tinggal pada /home
+C: nak tengok berapa space tinggal kat /home | /home tinggal berapa GB lagi
+R: nak check disk space kat /home | free space on /home berapa
+E: how much space is left on /home | show disk usage for /home
+
+cmd: df -h /
+F: Paparkan ruang cakera pada partition root
+C: nak tengok berapa space tinggal kat partition root | disk utama tinggal berapa
+R: nak check disk space kat root partition | show free space on /
+E: how much space is left on the root partition | show disk usage for /
+
+cmd: df -h .
+F: Paparkan ruang cakera pada partition direktori semasa
+C: nak tengok space tinggal kat disk folder ni | partition folder ni tinggal berapa
+R: nak check disk space kat current folder punya partition | free space here berapa
+E: how much disk space is left on this partition | show free space for the current directory's disk
+
+cmd: df -hT
+F: Paparkan penggunaan cakera beserta jenis sistem fail setiap partition
+C: nak tengok disk usage sekali dengan jenis filesystem dia | tunjuk space setiap partition dengan jenis dia
+R: nak check disk space with filesystem type | show disk usage plus fs type
+E: show disk usage with the filesystem type of each partition | list disk space including filesystem types
+
+cmd: df -h --total
+F: Paparkan penggunaan cakera semua partition beserta jumlah keseluruhan
+C: nak tengok disk usage semua partition dengan total sekali | berapa jumlah space semua disk
+R: nak check disk usage with total | show total disk space semua partition
+E: show disk usage for every partition with a grand total | how much total disk space do I have
+
+## --- du --------------------------------------------------------------------
+
+cmd: du -sh {d}
+F: Tunjukkan saiz keseluruhan direktori {d} | Paparkan jumlah saiz folder {d}
+C: berapa besar folder {d} ni | nak tahu saiz folder {d} | folder {d} makan berapa banyak space | tgk saiz {d}
+R: nak check size folder {d} | berapa besar folder {d} | folder {d} berapa MB | how big is {d}
+E: how big is the {d} folder | show the size of the {d} directory | how much space does {d} take
+
+cmd: du -sh {f}
+F: Tunjukkan saiz fail {f}
+C: berapa besar fail {f} ni | nak tahu saiz {f} | fail {f} berapa MB
+R: nak check size file {f} | berapa besar {f} | how big is file {f}
+E: how big is {f} | show the size of {f} | what is the size of the file {f}
+
+cmd: du -h --max-depth=1 {d}
+F: Paparkan saiz setiap sub-direktori di dalam {d}
+C: nak tengok saiz setiap folder dalam {d} | apa yang besar dalam folder {d} | tunjuk saiz semua sub-folder {d}
+R: nak check size setiap folder inside {d} | show size of each sub-folder in {d}
+E: show the size of each folder inside {d} | what takes up space in {d}
+
+## --- kill ------------------------------------------------------------------
+
+cmd: kill {pid}
+F: Hentikan proses dengan ID {pid} | Tamatkan proses {pid}
+C: nak matikan proses nombor {pid} | tolong bunuh proses {pid} | stop proses PID {pid} | matikan proses {pid} tu | nak stop program PID {pid}
+R: nak kill process {pid} | stop process id {pid} | matikan process PID {pid} | terminate process {pid}
+E: kill process {pid} | stop the process with PID {pid} | terminate process {pid}
+
+cmd: kill -9 {pid}
+F: Hentikan proses {pid} secara paksa
+C: nak matikan proses {pid} secara paksa, dia tak nak mati | bunuh terus proses {pid} | proses {pid} hang, matikan paksa
+R: nak force kill process {pid} | kill process {pid} yang hang tu | kill -9 {pid} terus
+E: force kill process {pid} | forcefully terminate PID {pid} | kill {pid} immediately
+
+cmd: kill $(lsof -t -i:{port})
+F: Hentikan proses yang menggunakan port {port}
+C: nak matikan proses yang guna port {port} | bunuh apa-apa yang tengah pakai port {port} | port {port} kena guna, matikan proses tu
+R: stop whatever is using port {port} | free up port {port} | kill process on port {port}
+E: stop whatever is listening on port {port} | free port {port} | kill whatever process is using port {port}
+
+cmd: kill -HUP {pid}
+F: Hantar isyarat HUP kepada proses {pid} supaya ia memuat semula konfigurasinya
+C: nak suruh proses {pid} reload config dia | hantar HUP kat proses {pid}
+R: nak send HUP to process {pid} | reload process {pid} config without restart
+E: send HUP to process {pid} to reload its config | reload process {pid} without restarting it
+
+cmd: kill $(pgrep {p})
+F: Hentikan semua proses bernama {p}
+C: nak matikan semua proses {p} | bunuh {p} yang tengah jalan | stop program {p}
+R: nak kill all {p} process | stop {p} yang running | kill {p}
+E: kill every {p} process | stop all running {p} processes | terminate {p}
+
+## --- zip -------------------------------------------------------------------
+
+cmd: zip -r {d}.zip {d}
+F: Mampatkan direktori {d} menjadi {d}.zip | Zipkan folder {d}
+C: nak zip folder {d} | mampatkan folder {d} jadi {d}.zip | tolong buat zip dari folder {d} | zipkan satu folder {d} | nak compress folder {d}
+R: nak zip folder {d} jadi {d}.zip | compress folder {d} to zip | buat zip file dari folder {d} | zip up {d}
+E: zip the {d} folder | compress the folder {d} into {d}.zip | make a zip of {d}
+
+cmd: zip {f}.zip {f}
+F: Mampatkan fail {f} menjadi {f}.zip
+C: nak zip fail {f} | mampatkan {f} jadi {f}.zip | tolong zipkan {f}
+R: nak zip file {f} | compress {f} to {f}.zip | zip {f}
+E: zip {f} | compress {f} into {f}.zip | make a zip of the file {f}
+
+cmd: zip -r {z} {d}
+F: Mampatkan direktori {d} ke dalam arkib {z}
+C: nak zip folder {d} nama dia {z} | mampatkan {d} jadi {z} | buat {z} dari folder {d}
+R: nak zip folder {d} into {z} | compress {d} to {z} | create {z} from folder {d}
+E: zip the folder {d} into {z} | compress {d} into an archive called {z}
+
+cmd: zip {z} {f} {f2}
+F: Mampatkan fail {f} dan {f2} ke dalam {z}
+C: nak zip {f} dan {f2} jadi {z} | masukkan {f} dengan {f2} dalam satu zip {z} | tolong zip dua fail {f} {f2} nama {z}
+R: nak zip {f} and {f2} into {z} | compress {f} dan {f2} to {z}
+E: zip {f} and {f2} into {z} | put {f} and {f2} into a zip called {z}
+
+cmd: zip -e {f}.zip {f}
+F: Mampatkan fail {f} menjadi {f}.zip dengan kata laluan
+C: nak zip {f} letak password | mampatkan {f} jadi zip yang ada password | tolong zip {f} kunci dengan password
+R: nak zip {f} with password | compress {f} to zip protected dengan password | password protect zip {f}
+E: zip {f} with a password | compress {f} into a password-protected zip
+
+cmd: zip -r {z} *.jpg
+F: Mampatkan semua fail .jpg dalam direktori ini menjadi {z}
+C: nak zip semua gambar jpg jadi {z} | masukkan semua fail jpg kat sini dalam {z}
+R: nak zip semua jpg into {z} | compress all jpg files to {z}
+E: zip all jpg files into {z} | put every .jpg here into {z}
+
+## --- unzip -----------------------------------------------------------------
+
+cmd: unzip {z}
+F: Ekstrak fail zip {z} | Nyahmampat {z} | Keluarkan kandungan arkib {z}
+C: nak buka fail zip {z} | tolong unzip {z} | keluarkan isi {z} | nak nyahmampat {z} | extract {z} kat sini | buka {z} ni | tlg unzip fail {z}
+R: nak unzip {z} | extract zip file {z} | buka {z} | unzip file {z} kat sini | nak extract {z}
+E: unzip {z} | extract {z} | open the zip file {z} | unpack {z}
+
+cmd: unzip {z} -d {d}
+F: Ekstrak {z} ke dalam direktori {d} | Nyahmampat {z} ke folder {d}
+C: nak unzip {z} masuk folder {d} | keluarkan isi {z} dalam folder {d} | extract {z} ke {d} | tolong unzip {z} letak dalam {d}
+R: nak unzip {z} into folder {d} | extract {z} ke folder {d} | unzip {z} to {d} | extract {z} inside {d}
+E: unzip {z} into the {d} folder | extract {z} to a folder called {d} | unpack {z} into {d}
+
+cmd: unzip -l {z}
+F: Senaraikan kandungan {z} tanpa mengekstraknya
+C: nak tengok apa ada dalam {z} tanpa unzip | tunjuk isi {z} je | apa fail dalam {z} tu | senarai isi zip {z}
+R: nak list content {z} without extract | tengok apa dalam {z} | show files inside {z} je
+E: list the files inside {z} without extracting | show what is in {z} | what does {z} contain
+
+cmd: unzip -o {z}
+F: Ekstrak {z} dan tulis ganti fail sedia ada tanpa bertanya
+C: nak unzip {z} terus overwrite, jangan tanya | extract {z} ganti fail lama terus
+R: nak unzip {z} overwrite existing files | extract {z} tanpa tanya, replace je
+E: unzip {z} overwriting existing files without asking | extract {z} and replace whatever is there
+
+cmd: unzip {d}/{z}
+F: Ekstrak fail zip {z} yang berada dalam direktori {d}
+C: nak unzip {z} yang ada dalam folder {d} | keluarkan isi {d}/{z} | extract fail zip dalam {d} nama {z}
+R: nak unzip {d}/{z} | extract {z} inside folder {d} | unzip file {z} dalam {d}
+E: unzip {d}/{z} | extract the zip {z} that is in the {d} folder
+
+cmd: unzip -q {z}
+F: Ekstrak {z} secara senyap tanpa memaparkan setiap fail
+C: nak unzip {z} tapi jangan print semua nama fail | extract {z} senyap-senyap je
+R: nak unzip {z} quietly | extract {z} without printing every file
+E: unzip {z} quietly | extract {z} without listing every file
+
+## --- ssh -------------------------------------------------------------------
+
+cmd: ssh {u}@{h}
+F: Sambung ke pelayan {h} sebagai pengguna {u} melalui SSH | Log masuk ke {h} sebagai {u}
+C: nak masuk server {h} guna user {u} | ssh ke {h} sebagai {u} | nak connect ke pelayan {h} dengan user {u} | tolong sambung ke {h}, user {u} | login {h} guna {u}
+R: nak ssh into {h} as {u} | connect to server {h} user {u} | remote masuk {h} as {u} | login ke {h} guna user {u}
+E: ssh into {h} as {u} | connect to the server {h} as user {u} | log in remotely to {h} as {u}
+
+cmd: ssh -p {sshport} {u}@{h}
+F: Sambung ke {h} melalui SSH pada port {sshport} sebagai {u}
+C: nak ssh ke {h} port {sshport} user {u} | masuk server {h} guna port {sshport} sebagai {u} | ssh {h} tapi port dia {sshport}, user {u}
+R: nak ssh {h} on port {sshport} as {u} | connect {h} port {sshport} user {u} | ssh into {h} guna port {sshport} as {u}
+E: ssh to {h} on port {sshport} as {u} | connect to {h} over ssh using port {sshport} as {u}
+
+cmd: ssh {h}
+F: Sambung ke pelayan {h} melalui SSH
+C: nak ssh ke {h} | masuk server {h} | nak connect ke {h} guna ssh
+R: nak ssh into {h} | connect to {h} | ssh {h}
+E: ssh into {h} | connect to {h} over ssh | log in to {h}
+
+## --- scp -------------------------------------------------------------------
+
+cmd: scp {f} {u}@{h}:~/
+F: Salin fail {f} ke direktori rumah pengguna {u} pada pelayan {h} | Muat naik {f} ke {h} sebagai {u}
+C: nak hantar {f} ke server {h} user {u} | copy fail {f} masuk pelayan {h} guna user {u} | upload {f} ke {h} sebagai {u} | tolong hantar fail {f} ke {u}@{h}
+R: nak copy {f} to server {h} as {u} | send {f} ke {h} via scp user {u} | upload {f} to {u}@{h} | scp {f} ke {h}, user {u}
+E: copy {f} to the server {h} as {u} | send {f} to {u}@{h} | upload {f} to {h} over ssh as {u}
+
+cmd: scp {u}@{h}:~/{f} .
+F: Salin fail {f} dari pelayan {h} (pengguna {u}) ke direktori semasa | Muat turun {f} daripada {h} sebagai {u}
+C: nak ambil {f} dari server {h} user {u} | download fail {f} dari pelayan {h} ke sini, user {u} | copy {f} dari {u}@{h} ke sini | tolong tarik {f} dari server {h} guna user {u}
+R: nak copy {f} from server {h} as {u} to here | download {f} dari {h} via scp user {u} | grab {f} from {u}@{h} | scp {f} from {h} to here, user {u}
+E: copy {f} from the server {h} to here as {u} | download {f} from {u}@{h} | fetch {f} from {h} over ssh as {u}
+
+cmd: scp -r {d} {u}@{h}:~/
+F: Salin direktori {d} ke pelayan {h} sebagai pengguna {u}
+C: nak hantar satu folder {d} ke server {h} user {u} | copy folder {d} masuk pelayan {h} sebagai {u} | upload folder {d} ke {u}@{h}
+R: nak copy folder {d} to server {h} as {u} | upload whole folder {d} via scp to {h}, user {u} | scp folder {d} ke {u}@{h}
+E: copy the {d} folder to the server {h} as {u} | upload the directory {d} to {u}@{h} over ssh
+
+cmd: scp {f} {u}@{h}:/tmp
+F: Salin fail {f} ke /tmp pada pelayan {h} sebagai {u}
+C: nak hantar {f} ke /tmp kat server {h}, user {u} | copy {f} masuk /tmp pelayan {h} guna {u}
+R: nak scp {f} to /tmp on {h} as {u} | send {f} ke {h} /tmp, user {u}
+E: copy {f} to /tmp on the server {h} as {u} | send {f} to {u}@{h} into /tmp
+
+cmd: scp -P {sshport} {f} {u}@{h}:~/
+F: Salin fail {f} ke pelayan {h} pada port {sshport} sebagai {u}
+C: nak hantar {f} ke server {h} port {sshport} user {u} | scp {f} ke {h} tapi port dia {sshport}, user {u}
+R: nak scp {f} to {h} port {sshport} as {u} | upload {f} ke {u}@{h} using port {sshport}
+E: copy {f} to {h} on port {sshport} as {u} | scp {f} to {u}@{h} using port {sshport}
+
+cmd: scp -r {u}@{h}:~/{d} .
+F: Salin direktori {d} dari pelayan {h} (pengguna {u}) ke direktori semasa
+C: nak ambil folder {d} dari server {h} user {u} | download satu folder {d} dari pelayan {h} sebagai {u} ke sini
+R: nak copy folder {d} from {h} as {u} to here | download folder {d} dari {u}@{h} via scp
+E: copy the folder {d} from the server {h} to here as {u} | download the directory {d} from {u}@{h}
+
+## --- wget ------------------------------------------------------------------
+
+cmd: wget {url}
+F: Muat turun fail dari {url} | Dapatkan fail di {url}
+C: nak download {url} | tolong muat turun fail dari {url} | download fail kat {url} | nak ambil {url} | muat turun {url} ke sini
+R: nak download {url} | download file dari {url} | grab {url} | fetch {url} to here
+E: download {url} | fetch the file at {url} | save {url} to this folder
+
+cmd: wget -c {url}
+F: Sambung semula muat turun {url} yang terhenti
+C: nak sambung download {url} yang putus tadi | resume download {url} | download {url} tergendala, sambung balik
+R: nak resume download {url} | continue download {url} yang tergendala | wget {url} resume
+E: resume downloading {url} | continue an interrupted download of {url}
+
+cmd: wget -P {d} {url}
+F: Muat turun {url} ke dalam direktori {d}
+C: nak download {url} terus masuk folder {d} | muat turun {url} simpan dalam {d} | tolong download {url} ke folder {d}
+R: nak download {url} into folder {d} | save {url} to {d} | wget {url} masuk {d}
+E: download {url} into the {d} folder | save {url} to {d}
+
+## --- top -------------------------------------------------------------------
+
+cmd: top
+F: Paparkan proses yang sedang berjalan secara langsung | Pantau penggunaan CPU dan memori secara masa nyata
+C: nak tengok proses secara live | tunjuk apa yang makan CPU sekarang | nak monitor proses yang jalan | apa yang buat laptop ni slow | tgk proses live
+R: nak monitor process live | show top process | what is eating my CPU | check process usage real time
+E: show running processes live | monitor cpu and memory in real time | what is using my cpu right now
+
+cmd: top -u {u}
+F: Pantau proses milik pengguna {u} secara langsung
+C: nak tengok proses user {u} je secara live | monitor apa yang {u} tengah jalankan | tunjuk proses {u} dalam top
+R: nak monitor process user {u} live | show top for user {u} | top process belonging to {u}
+E: monitor processes owned by {u} live | show top for user {u} only | watch what {u} is running
+
+cmd: top -p {pid}
+F: Pantau proses {pid} secara langsung
+C: nak monitor proses {pid} je secara live | tengok proses PID {pid} dalam top | pantau proses {pid} makan berapa CPU
+R: nak monitor process {pid} live | show top for PID {pid} only | watch process {pid}
+E: monitor process {pid} live | show top for PID {pid} only | watch the cpu use of process {pid}
+
+cmd: top -o %MEM
+F: Paparkan proses disusun mengikut penggunaan memori tertinggi
+C: nak tengok proses mana yang makan RAM paling banyak | susun proses ikut memori dalam top
+R: nak monitor process sorted by memory | show top sort by RAM | which process makan memory paling banyak
+E: show processes sorted by memory usage | which process is using the most memory | top sorted by RAM
+
+cmd: top -d {n}
+F: Pantau proses secara langsung dengan kemas kini setiap {n} saat
+C: nak tengok top tapi refresh setiap {n} saat | monitor proses, update tiap {n} saat
+R: nak run top with {n} second refresh | monitor process live, refresh every {n} seconds
+E: monitor processes refreshing every {n} seconds | run top with a {n} second delay
+
+cmd: top -n 1
+F: Paparkan senarai proses sekali sahaja tanpa kemas kini berterusan
+C: nak tengok output top sekali je, tak nak dia refresh | tunjuk proses macam top tapi terus keluar
+R: nak run top once and exit | show top output sekali je
+E: show top output once and exit | run top for a single iteration
+
+## --- free ------------------------------------------------------------------
+
+cmd: free -h
+F: Paparkan penggunaan memori RAM dalam unit yang mudah dibaca | Tunjukkan jumlah RAM yang digunakan dan yang masih kosong
+C: nak tengok RAM tinggal berapa | berapa memori yang tengah guna | tgk RAM usage | RAM ni penuh ke tak | berapa RAM free sekarang | nak check memori laptop ni | tunjuk penggunaan RAM
+R: nak check RAM usage | berapa memory free sekarang | show RAM tinggal berapa | check memory usage laptop ni | RAM used berapa GB
+E: how much RAM is free | show memory usage | check RAM usage | how much memory is my machine using
+
+cmd: free -m
+F: Paparkan penggunaan memori dalam megabait
+C: nak tengok RAM dalam MB | tunjuk memori guna berapa MB | RAM tinggal berapa MB
+R: nak check RAM usage in MB | show memory in megabytes | free memory berapa MB
+E: show memory usage in megabytes | how much RAM is used, in MB
+
+cmd: free -g
+F: Paparkan penggunaan memori dalam gigabait
+C: nak tengok RAM dalam GB | RAM tinggal berapa GB
+R: nak check RAM in GB | show memory usage in gigabytes
+E: show memory usage in gigabytes | how many GB of RAM are free
+
+cmd: free -h -s {n}
+F: Paparkan penggunaan memori setiap {n} saat secara berterusan
+C: nak tengok RAM usage refresh setiap {n} saat | monitor memori tiap {n} saat | tunjuk RAM setiap {n} saat
+R: nak monitor RAM usage every {n} seconds | check memory setiap {n} saat | show RAM usage refresh every {n}s
+E: show memory usage every {n} seconds | monitor RAM refreshing every {n} seconds
+
+cmd: free -t
+F: Paparkan penggunaan memori beserta jumlah RAM dan swap
+C: nak tengok RAM dengan swap sekali, ada total | tunjuk jumlah memori campur swap
+R: nak check RAM plus swap total | show memory usage with total line
+E: show memory usage with a total for RAM plus swap | how much memory and swap combined

--- a/dataset/head.py
+++ b/dataset/head.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Grow the head of the pool for the beginner verbs (issue #62). Stdlib only.
+
+  python3 head.py out/pool_v7.jsonl out/pool_v8.jsonl
+
+Run 9 capped the tail and `git` went 4.3% -> 5.8% of the pool; `delete
+file` came back `git obliterate` and `list processes` `pm2`. `nano` has 53
+rows, `less` 90, `ps` 880 against `git` 13k. Nothing in the sources fills
+that: the rows prior.py dropped for these tools are tldr placeholders whose
+NL never named the file, and the rows disambiguate.py dropped are pipe
+one-liners. So the head is written, basics.txt style, in basics_head.txt:
+same block format plus slots -- `{f}` any file, `{t}` text file, `{d}`
+folder, `{u}` user, `{h}` host, `{n}` count, `{pid}`, `{p}` process, `{z}`
+zip, `{url}`, `{port}`, `{sshport}`, `{log}` -- filled from NAMES, K expansions per block, the
+k-th name of every list, so `rm {f}` / `nak buang fail {f}` becomes twenty
+consistent pairs. A phrasing must carry every slot its cmd carries: a row
+whose NL never names what the command names is the placeholder bug again.
+
+Budget per tool: min(CAP, TARGET - real rows), real = rows in the source
+pool whose id is not an augment_verbs `+verb` or rebalance `~i` duplicate;
+tools at or above TARGET get nothing. Whole tasks (one expansion of one
+block, all registers) are sampled with prior.sample_ids, seed 42. CAP is
+`mkdir`'s row count in pool_v7 so no single tool jumps past the head it is
+meant to join. Tools the probe holds out (training/probe.py HOLDOUT) are
+refused: a head row for `chsh` would un-hold it.
+
+Issue #51 rides along: the translation step turned `file.txt` in the NL
+into `fail.txt` while the command kept `file.txt`, and the model learned
+Malay-name -> English-name as a mapping. Where a non-English row's command
+names exactly one file the NL does not, and the NL names exactly one file
+the command does not whose stem is the Malay of it (`fail1.csv` for
+`file1.csv`, `dokumen.zip` for `documents.zip`), the NL gets the command's
+name back. Commands are never touched. Every slot list carries Malay
+filenames (lama.txt, nota.txt, laporan.pdf, projek) byte-identical on both
+sides, which is the positive example the pool never had.
+"""
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+from basics import parse
+from prior import sample_ids
+from rebalance import tool
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TARGET, SEED = 1000, 42
+# tools training/probe.py HOLDOUT measures generalisation on; keep them unwritten
+HOLDOUT = {"truncate", "tac", "whereis", "dirname", "tee", "timeout", "chsh",
+           "printenv", "nl"}
+
+NAMES = {
+    "t": "notes.txt nota.txt lama.txt laporan.txt senarai.txt surat.txt jadual.csv "
+         "data.csv todo.md catatan.md draf.txt minit.txt ucapan.txt config.yaml "
+         "index.html main.py skrip.sh output.log error.log resit.txt".split(),
+    "f": "laporan.pdf gambar.jpg nota.txt lama.txt foto.png resume.docx senarai.txt "
+         "video.mp4 muzik.mp3 slaid.pptx notes.txt data.csv borang.pdf sijil.pdf "
+         "logo.png tesis.docx jadual.xlsx surat.txt cover.jpg dokumen.pdf".split(),
+    "d": "projek dokumen gambar backup tugasan kerja arkib muzik laporan Downloads "
+         "Documents src data foto nota video projek_lama sekolah kuliah borang".split(),
+    "u": "ariff ali siti root admin aiman farah hafiz nurul amir azman mei kumar "
+         "danial aina hana izzat www-data ubuntu pi".split(),
+    "h": "192.168.1.10 192.168.0.20 10.0.0.12 server.local example.com myserver.com "
+         "172.16.0.3 pi.local 203.0.113.7 vps.example.com 10.1.1.4 192.168.1.100 "
+         "dev.example.com 10.0.1.9 staging.local 192.168.100.5 host.example.org "
+         "10.10.10.10 nas.local 172.20.0.8".split(),
+    "n": "10 20 5 50 100 3 15 30 25 40 8 12 200 7 60 2 500 1000 45 90".split(),
+    "pid": "1234 5678 2201 987 4410 3345 1502 7788 6001 2048 913 3210 4499 1867 "
+           "7002 2555 8123 640 3999 5150".split(),
+    "p": "nginx python3 node firefox chrome mysql docker sshd apache2 java code vim "
+         "redis postgres php ffmpeg spotify slack gnome-shell bash".split(),
+    "z": "backup.zip gambar.zip projek.zip dokumen.zip arkib.zip laporan.zip data.zip "
+         "foto.zip tugasan.zip source.zip kerja.zip muzik.zip borang.zip notes.zip "
+         "release.zip sekolah.zip kuliah.zip video.zip resit.zip slaid.zip".split(),
+    "url": ["https://example.com/" + x for x in
+            "laporan.pdf data.csv setup.sh gambar.jpg backup.zip notes.txt video.mp4 "
+            "app.tar.gz index.html muzik.mp3 borang.pdf foto.png data.json release.zip "
+            "config.yaml tesis.docx logo.png senarai.txt skrip.sh arkib.zip".split()],
+    "port": "22 2222 8080 3000 5000 443 80 8000 2200 9000 5432 3306 6379 8443 "
+            "22022 4000 8888 1234 7000 8081".split(),
+    "sshport": "2222 2200 22022 2202 8022 2022 10022 2223 2224 22222 4422 2233 "
+               "2244 2255 2266 2277 2288 2299 6222 22".split(),
+    "log": "output.log error.log access.log debug.log system.log nginx.log build.log "
+           "install.log backup.log sync.log cron.log worker.log api.log db.log "
+           "test.log deploy.log run.log update.log service.log audit.log".split(),
+}
+K = 20
+assert all(len(v) == K for v in NAMES.values())
+SLOT = re.compile(r"\{(t|f2|f|d2|d|u|h|n|pid|sshport|port|p|z|url|log)\}")
+
+
+def fill(text, k):
+    """Slot k of every list; `{f2}`/`{d2}` are the same lists shifted by 7."""
+    def one(m):
+        s = m.group(1)
+        return NAMES[s[0]][(k + 7) % K] if s in ("f2", "d2") else NAMES[s][k % K]
+    return SLOT.sub(one, text)
+
+
+def expand(path):
+    """basics_head.txt -> [(task_id, cmd, {register: [nl]})], slots filled."""
+    out = []
+    for b, (cmd, regs) in enumerate(parse(path)):
+        slots = set(SLOT.findall(cmd))
+        if tool(cmd) in HOLDOUT:
+            raise ValueError(f"{cmd!r}: {tool(cmd)} is a probe HOLDOUT tool")
+        for reg, phrs in regs.items():
+            for p in phrs:
+                if slots - set(SLOT.findall(p)):
+                    raise ValueError(f"{cmd!r}: {reg} phrasing {p!r} misses a slot")
+        for k in range(K if slots else 1):
+            out.append((f"head:{b}.{k}", fill(cmd, k),
+                        {reg: [fill(p, k) for p in phrs] for reg, phrs in regs.items()}))
+    return out
+
+
+def rows(path):
+    for tid, cmd, regs in expand(path):
+        for reg, phrs in regs.items():
+            for j, nl in enumerate(phrs):
+                yield {"id": f"{tid}.{j}", "register": reg, "nl": nl, "cmd": cmd}
+
+
+def real(pool):
+    """Rows per tool, augment_verbs / rebalance duplicates not counted."""
+    return Counter(tool(r["cmd"]) for r in pool
+                   if "+" not in r["id"] and "~" not in r["id"])
+
+
+def budget(pool, cap):
+    return {t: min(cap, TARGET - n) for t, n in real(pool).items() if n < TARGET}
+
+
+def pick(head, budgets):
+    """Head rows cut to budget per tool, whole tasks, seed 42; no budget, no rows."""
+    by_tool = defaultdict(list)
+    for r in head:
+        by_tool[tool(r["cmd"])].append(r)
+    keep = set()
+    for t, rs in sorted(by_tool.items()):
+        tasks = [{**r, "id": r["id"].rsplit(".", 1)[0]} for r in rs]
+        want = budgets.get(t, 0)
+        keep |= sample_ids(tasks, want, SEED)
+    return [r for r in head if r["id"].rsplit(".", 1)[0] in keep]
+
+
+# --- issue #51 -------------------------------------------------------------
+FILENAME = re.compile(r"(?<![\w/.%$-])([A-Za-z][\w-]*\.(?:txt|pdf|csv|log|md|jpg|"
+                      r"jpeg|png|gif|zip|tar|gz|sh|py|json|xml|html|conf|cfg|bak|"
+                      r"doc|docx|xls|xlsx|ppt|pptx|mp3|mp4|iso|deb))\b")
+
+
+# stems the translator produced in the NL for a name the command spells in English
+STEM = {"fail": "file", "dokumen": "documents", "teks": "text", "senarai": "list",
+        "arkib": "archive", "arsip": "archive", "sumber": "source", "dalam": "in",
+        "luar": "out"}
+
+
+def restore_name(nl, cmd):
+    """NL with the command's filename back where the translator renamed it."""
+    c, l = set(FILENAME.findall(cmd)), set(FILENAME.findall(nl))
+    miss, extra = c - l, l - c
+    if len(miss) == 1 and len(extra) == 1:
+        (m,), (e,) = miss, extra
+        for bm, en in STEM.items():
+            if e.startswith(bm) and en + e[len(bm):] == m:
+                return nl.replace(e, m)
+    return nl
+
+
+def report(label, pool):
+    cnt = Counter(tool(r["cmd"]) for r in pool)
+    top30 = sum(n for _, n in cnt.most_common(30))
+    print(f"{label}: {len(pool)} rows, {len(cnt)} first tokens, "
+          f"top-30 share {100*top30/len(pool):.1f}%, "
+          f"git {100*cnt['git']/len(pool):.1f}%, find {100*cnt['find']/len(pool):.1f}%")
+    return cnt
+
+
+def main():
+    src, dst = sys.argv[1], sys.argv[2]
+    head_txt = sys.argv[3] if len(sys.argv) > 3 else os.path.join(HERE, "basics_head.txt")
+    pool = [json.loads(l) for l in open(src, encoding="utf-8")]
+    before = report("before", pool)
+    cap = before["mkdir"]
+
+    renamed = 0
+    for r in pool:
+        if r["register"] != "english":
+            nl = restore_name(r["nl"], r["cmd"])
+            renamed += nl != r["nl"]
+            r["nl"] = nl
+
+    head = list(rows(head_txt))
+    budgets = budget(pool, cap)
+    added = pick(head, budgets)
+    out = pool + added
+    after = report("after", out)
+
+    print(f"#51 filenames restored in NL: {renamed}; head written {len(head)}, "
+          f"added {len(added)} (cap {cap}, target {TARGET})")
+    print(f"{'tool':10} {'v7':>6} {'real':>6} {'budget':>6} {'added':>6} {'v8':>6}")
+    got = Counter(tool(r["cmd"]) for r in added)
+    for t in sorted({tool(r["cmd"]) for r in head}, key=lambda t: -got[t]):
+        print(f"{t:10} {before[t]:>6} {real(pool)[t]:>6} {budgets.get(t, 0):>6} "
+              f"{got[t]:>6} {after[t]:>6}")
+    with open(dst, "w", encoding="utf-8") as f:
+        for r in out:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"wrote {len(out)} rows -> {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dataset/lists.py
+++ b/dataset/lists.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Drop rows whose command carries tldr's list/name placeholder idiom.
+
+    python3 lists.py out/pool_v8.jsonl out/pool_v9.jsonl
+
+`file1 file2 ...`, `argument1 argument2 ...`, `filename`, `file_name`,
+`file_or_directory`, `directory_name`, `folder_name`: prior.py's rule caught
+`path/to` and `<name>`, not these. Their NL is generic ("erase specific
+files") and their command is not runnable, so together they teach the exact
+wrong thing (issue #62: `git obliterate file_1 file_2 ...` answered
+`nak delete file ni je`). Whole pairs go: every row sharing the id stem.
+"""
+import json, re, sys
+
+LIST = re.compile(
+    r"\b(\w+?)_?1 \1_?2\b|\s\.\.\.(?=\s|$)|\b(?:file_?name|file_or_directory|directory_name|folder_name)\b"
+)
+
+
+def stem(rid: str) -> str:
+    return re.split(r"[+~]", rid, maxsplit=1)[0]
+
+
+def main(src: str, dst: str) -> None:
+    rows = [json.loads(l) for l in open(src) if l.strip()]
+    bad = {stem(r["id"]) for r in rows if LIST.search(r["cmd"])}
+    keep = [r for r in rows if stem(r["id"]) not in bad]
+    with open(dst, "w") as f:
+        for r in keep:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"{src}: {len(rows)} rows -> {dst}: {len(keep)} rows, dropped {len(rows)-len(keep)} ({len(bad)} pairs)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/dataset/test_pipeline.py
+++ b/dataset/test_pipeline.py
@@ -252,3 +252,61 @@ _k = sample_ids(_rows, 30)
 assert _k == sample_ids(_rows, 30) and 30 <= 4 * len(_k) < 34, _k
 assert sample_ids(_rows, 1000) == {f"t:{i}" for i in range(50)}
 print("ok: prior checks pass")
+
+# --- head.py (issue #62: slot expansion, per-tool budget, #51 filename restore)
+from head import K, budget, expand, fill, pick, restore_name
+
+# every slot of the cmd must be in every phrasing; a NL that never names what
+# the command names is the placeholder bug that prior.py removed
+got = _parse_text("cmd: rm {f}\nF: Padam fail {f}\nC: buang {f}\nR: delete {f}\nE: delete {f}\n")
+with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf-8") as _f:
+    _f.write("cmd: rm {f} {f2}\nF: Padam {f} dan {f2}\nC: buang {f} {f2}\nR: delete {f} {f2}\nE: delete {f} and {f2}\n\n"
+             "cmd: free -h\nF: Paparkan RAM\nC: RAM berapa\nR: check RAM\nE: show RAM\n")
+_x = expand(_f.name)
+os.unlink(_f.name)
+assert len(_x) == K + 1, len(_x)                       # slotted block x K, plain block x 1
+assert _x[0][1] == "rm laporan.pdf video.mp4" and _x[0][2]["english"] == ["delete laporan.pdf and video.mp4"]
+assert all(cmd.split()[1] != cmd.split()[2] for _, cmd, _ in _x[:K])   # {f} != {f2}
+assert _x[K] == ("head:1.0", "free -h", {"formal": ["Paparkan RAM"], "colloquial": ["RAM berapa"],
+                                          "rojak": ["check RAM"], "english": ["show RAM"]})
+for bad in ("cmd: rm {f}\nF: Padam fail\nC: buang {f}\nR: delete {f}\nE: delete {f}\n",  # F misses {f}
+            "cmd: chsh -s /bin/zsh\nF: x\nC: x\nR: x\nE: x\n"):                        # probe HOLDOUT tool
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf-8") as _f:
+        _f.write(bad)
+    try:
+        expand(_f.name)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(f"accepted bad head block: {bad!r}")
+    finally:
+        os.unlink(_f.name)
+assert fill("nano {d}/{t}", 3) == "nano backup/laporan.txt"
+
+# budget counts real rows only: augment `+verb` and rebalance `~i` ids are duplicates
+_pool = ([{"id": f"a:{i}", "cmd": "nano x"} for i in range(30)] +
+         [{"id": f"a:{i}+padam", "cmd": "nano x"} for i in range(30)] +
+         [{"id": f"b:{i}", "cmd": "git status"} for i in range(1200)])
+assert budget(_pool, cap=918)["nano"] == 918 and budget(_pool, cap=50)["nano"] == 50
+assert "git" not in budget(_pool, cap=918)
+assert budget(_pool + [{"id": f"c:{i}", "cmd": "less y"} for i in range(990)], cap=918)["less"] == 10
+# pick: whole tasks, cut to budget, no budget -> no rows, deterministic
+_head = [{"id": f"head:{b}.{k}.{j}", "register": reg, "cmd": f"nano f{k}"}
+         for b in range(2) for k in range(K) for j, reg in enumerate(("formal", "colloquial", "rojak", "english"))]
+_head += [{"id": "head:9.0.0", "register": "formal", "cmd": "git status"}]
+_p = pick(_head, {"nano": 40})
+assert 40 <= len(_p) < 44 and _p == pick(_head, {"nano": 40}) and not any("git" in r["cmd"] for r in _p)
+assert len({r["id"].rsplit(".", 1)[0] for r in _p}) * 4 == len(_p)   # every kept task has all 4 rows
+
+# #51: the translator renamed the file in the NL, the command kept it
+for nl, cmd, want in (
+        ("Cetak bilangan baris dalam fail.txt", "wc -l file.txt", "Cetak bilangan baris dalam file.txt"),
+        ("nak zip folder ni jadi dokumen.zip", "zip -r documents.zip docs", "nak zip folder ni jadi documents.zip"),
+        ("gabung fail1.csv dengan data.csv", "join file1.csv data.csv", "gabung file1.csv dengan data.csv"),
+        # both sides already agree, or the command names two files: untouched
+        ("nak buang lama.txt", "rm lama.txt", "nak buang lama.txt"),
+        ("tukar dokumen.pdf jadi dua", "pdftk in.pdf out.pdf", "tukar dokumen.pdf jadi dua"),
+        # a different English name is not a translation (`build.xml` vs `buildfile.xml`)
+        ("guna fail selain build.xml", "ant -f buildfile.xml", "guna fail selain build.xml")):
+    assert restore_name(nl, cmd) == want, (nl, cmd, restore_name(nl, cmd))
+print("ok: head checks pass")

--- a/dataset/test_pipeline.py
+++ b/dataset/test_pipeline.py
@@ -310,3 +310,14 @@ for nl, cmd, want in (
         ("guna fail selain build.xml", "ant -f buildfile.xml", "guna fail selain build.xml")):
     assert restore_name(nl, cmd) == want, (nl, cmd, restore_name(nl, cmd))
 print("ok: head checks pass")
+
+# lists.py: tldr's list/name placeholder idiom, whole pairs go
+from lists import LIST, stem
+for cmd, hit in (
+        ("git obliterate file_1 file_2 ...", True), ("nohup command argument1 argument2 ...", True),
+        ("rm filename", True), ("chmod 644 file_or_directory", True), ("mkdir directory_name", True),
+        ("rm notes.txt", False), ("touch file{1..5}", False), ("ls -1", False), ("cat file2.txt", False),
+        ("mv a1 b2", False), ("git log --oneline -3", False)):
+    assert bool(LIST.search(cmd)) == hit, cmd
+assert stem("tldr:12+verb") == stem("tldr:12~3") == "tldr:12"
+print("ok: lists checks pass")

--- a/training/probe.py
+++ b/training/probe.py
@@ -596,20 +596,21 @@ def main():
                     help="re-apply the current regexes to a saved run; no server")
     args = ap.parse_args()
 
-    # The probe must not score its own training data. dataset/basics.txt is
-    # hand-written and lives next door, so check every prompt against it.
-    basics_txt = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                              "..", "dataset", "basics.txt")
-    if os.path.exists(basics_txt):
+    # The probe must not score its own training data. dataset/basics.txt and
+    # basics_head.txt (issue #62, slots expanded) are hand-written and live
+    # next door, so check every prompt against both.
+    dataset = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "dataset")
+    if os.path.exists(os.path.join(dataset, "basics.txt")):
         import sys
-        sys.path.insert(0, os.path.dirname(basics_txt))
-        from basics import parse as parse_basics
-        train = {p.lower() for _, regs in parse_basics(basics_txt)
-                 for ps in regs.values() for p in ps}
+        sys.path.insert(0, dataset)
+        from basics import rows as basics_rows
+        from head import rows as head_rows
+        train = {r["nl"].lower() for r in basics_rows(os.path.join(dataset, "basics.txt"))}
+        train |= {r["nl"].lower() for r in head_rows(os.path.join(dataset, "basics_head.txt"))}
         leaked = [p for t in TASKS + HOLDOUT for p in t["p"].values()
                   if p.lower() in train]
         if leaked:
-            raise SystemExit(f"probe prompts present in basics.txt: {leaked}")
+            raise SystemExit(f"probe prompts present in basics*.txt: {leaked}")
 
     if args.rescore:
         okre = {t["task"]: t["ok"] for t in TASKS + HOLDOUT}


### PR DESCRIPTION
Closes #62.

Dataset: `dataset/head.py` + `basics_head.txt` (11,676 generated four-register rows for the beginner tools under ~1,000 real rows, Malay filenames byte-identical on both sides — #51's mechanism), `dataset/lists.py` (drops 4,864 tldr `file1 file2 ...` / `filename` list-placeholder rows), tests in `test_pipeline.py`, `probe.py` leak check covers `basics_head.txt`.

Run 10 (`qwen-v8`, `qwen-v8-dpo`) and run 11 (`qwen-v9`, `qwen-v9-dpo`), all vs the shipped v0.9.0 model: every register inside the CI, probe 204–206 vs 205, `edit file`/`change permission`/`list processes` fixed (5/5, 5/5, 4/4), `delete file` broken (0–2 of 6) because the six probe phrasings are unnamed and the pool has zero unnamed `rm` rows — #47's gap, delete side. Holdout 34 → 29 on v9-dpo. Nothing ships; RESULTS.md has both write-ups and what the next run would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)