### PR TITLE
fix(dataset): Malay filenames byte-identical (#51): mv rename block, baru.txt slot, probe exact section

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1458,3 +1458,42 @@ prompt still comes back translated — then 236 rows are not enough weight
 against the prior and the lever is DPO pairs on exactly that shape, not
 more SFT rows. Ship rule unchanged: the README quoting workaround comes
 out only when a shipped model shows 8/8.
+
+**Result (2026-08-18): falsified on the one prompt it was for.** `qwen-v10`
+235,159 rows, then `qwen-v10-dpo` on its own probe misses (3,432 pairs;
+`exact` prompts get no pairs — they are not in dpo_pairs.py's GOLD, so
+`#51 exact` stays a generalisation number after DPO).
+
+| register | shipped (v7-dpo) | v10 | v10-dpo | v10-dpo vs shipped, 95% CI | p |
+|---|---|---|---|---|---|
+| BM | 0.497 | 0.453 | 0.453 | −0.043 [−0.097, +0.011] | 0.15 |
+| rojak | 0.517 | 0.480 | 0.490 | −0.027 [−0.083, +0.029] | 0.42 |
+| EN | 0.543 | 0.523 | 0.543 | 0.000 [−0.050, +0.050] | 1 |
+
+Inside every CI. Probe: v10 basics 160, holdout 33; v10-dpo basics 166,
+holdout 32 (shipped 166 / 34); `path/to` 0. `delete file` 5/6 on v10-dpo
+(v9-dpo 2/6) with nothing in this pool aimed at it — the churn again. Bench
+0.54 s warm at 4 threads, 1.58 GB RSS.
+
+`#51 exact` **7/8 on both**, the same miss: `nak rename fail baru.txt jadi
+lama.txt` → `mv new.txt old.txt`. But the rename block did land — on v10,
+`nak tukar nama fail lama.txt jadi baru.txt` → `mv lama.txt baru.txt`,
+`rename nota.txt ke surat.txt` → `mv nota.txt surat.txt`, `nak rename fail
+a.txt jadi b.txt` → `mv a.txt b.txt`. Every phrasing that carries
+`baru.txt` before `lama.txt` (`kepada`, `jadi`, `to`, `boleh?`) comes back
+`mv new.txt old.txt`, which is basics.txt's own rename block (`nak tukar
+nama fail old.txt jadi new.txt` → `mv old.txt new.txt`, 28 rows) reached
+through the prior `baru`=new, `lama`=old. `lama.txt` is in the slot lists
+(345 rows) and survives; `baru.txt` is in zero pool rows and does not. So
+the miss is not the rename shape, it is the one Malay filename the lists
+never carried.
+
+**Run 13, hypothesis before the run.** `pool_v11` = pool_v10 with
+`baru.txt` in place of `notes.txt` in the `{t}` list (head.py NAMES): 220
+rows change, `notes.txt` → `baru.txt` on both sides, nothing else moves
+(checked row for row). One variable. Hypothesis: `#51 exact` 8/8, ALFA
+inside the CI vs shipped, probe within the ±3 churn. Falsified if the
+rename still comes back `new.txt old.txt` with 220 rows naming `baru.txt` —
+then a Malay word that is also an adjective needs more than the ~200-row
+dose `lama.txt` needed, and the honest fix is the README line, not more
+rows.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1497,3 +1497,34 @@ rename still comes back `new.txt old.txt` with 220 rows naming `baru.txt` —
 then a Malay word that is also an adjective needs more than the ~200-row
 dose `lama.txt` needed, and the honest fix is the README line, not more
 rows.
+
+**Result (2026-08-18): hypothesis held on #51, ALFA says no ship.** `qwen-v11`
+235,159 rows, then `qwen-v11-dpo` (3,428 pairs).
+
+| register | shipped (v7-dpo) | v11 | v11-dpo | v11-dpo vs shipped, 95% CI | p |
+|---|---|---|---|---|---|
+| BM | 0.497 | 0.433 | 0.423 | **−0.073 [−0.125, −0.022]** | 0.008 |
+| rojak | 0.517 | 0.480 | 0.477 | −0.040 [−0.092, +0.012] | 0.17 |
+| EN | 0.543 | 0.517 | 0.527 | −0.017 [−0.070, +0.037] | 0.63 |
+
+`#51 exact` **8/8** on v11 and v11-dpo; every rename phrasing right
+(`nak tukar nama fail baru.txt kepada lama.txt`, `rename file baru.txt to
+lama.txt`, `... boleh?` all → `mv baru.txt lama.txt`). 220 rows naming
+`baru.txt` were the dose. Probe: v11 basics 164 / holdout 31; v11-dpo
+basics **169** / holdout 31, `delete file` **6/6** on both, `path/to` 0.
+Bench 0.52 s warm at 4 threads, 1.56 GB RSS.
+
+Not shipping: BM is worse than v0.9.0 and the CI excludes zero — the first
+time in this thread it has. v10-dpo → v11-dpo alone is −0.030 [−0.075,
++0.015] (p = 0.24), inside the noise, and two of the 28 BM losses are the
+same command scored pass then fail (`gzip -k /testbed/hello.php`), so the
+220-row swap is not what moved BM. What moved it is the whole head-row
+family: v7-dpo 0.497 → v8-dpo 0.497 → v9-dpo 0.477 → v10-dpo 0.453 →
+v11-dpo 0.423, each step inside its CI, the sum not. Runs 10–13 each fixed
+what they named on the probe (edit, chmod, ps, rename, Malay names, now
+`delete file` too) and paid for it on ALFA a little at a time. Issue #51
+is answered — the data fix is `basics_head.txt` + the `{t}` list, verified
+8/8 — and it ships with whatever next model clears ALFA. The README
+quoting workaround stays until then. Next lever, if this thread continues:
+find which ALFA-BM tasks the head-row family loses (v7-dpo right, v11-dpo
+wrong, 43 of them) and whether they share a tool the head rows out-vote.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1414,3 +1414,47 @@ core tool (`<Enter>`, `pvesm`), bundled with the next change that has an
 ALFA-sized reason to retrain — not on their own. `dataset/lists.py` stays
 (4,864 unrunnable rows out is right regardless), pool_v9 is the pool the
 next run starts from.
+
+## Issue #51: Malay filenames come back translated (no run)
+
+**Measured (2026-08-18), no GPU.** Eight exact-output prompts, now
+`EXACT` in `training/probe.py` (printed as `#51 exact n/8`; the two that
+turned out to be head-row phrasings were reworded — the leak check caught
+them). Whole line must match, e.g. `nak delete lama.txt` → `rm lama.txt`.
+
+| model | #51 exact | misses |
+|---|---|---|
+| shipped v0.9.0 (v7-dpo) | **2/8** | `rm old.txt`, `mv new.txt old.txt`, `cat note.txt`, `cp report.pdf work/`, `rm -f files/images_lager.jpg`, `rm list_of_files.txt` |
+| qwen-v8-dpo (run 10) | 7/8 | `mv new.txt old.txt` |
+| qwen-v9 / v9-dpo (run 11) | 7/8 | `mv new_file_name old_file_name` / `mv new_file.txt old_file.txt` |
+
+The issue's hypothesis — the pool holds `lama.txt` in the NL against
+`old.txt` in the command — is falsified: `grep lama.txt | grep old.txt` is
+0 in pool_v5 and pool_v9, and a scan of every NL filename absent from its
+command finds 219 rows in pool_v9, all legitimate mentions (`Node.js`,
+`output.txt` for tesseract's implied output, `0.5s`). The mapping is the
+base model's translation prior, and what pushes back is run 10's head rows
+with Malay names on both sides (`lama.txt`, `nota.txt`, `laporan.pdf`,
+`senarai.txt`, `projek`): 2/8 → 7/8 without a row that names the fix.
+
+The one that stays is the two-file rename. `basics_head.txt` has
+`mv {d} {d2}` (folder) and `mv {t} {t}.old` but no `mv file other-file`,
+so the model falls back to the prior. Added: `mv {t} {t2}` block (`nak
+tukar nama fail {t} jadi {t2}`, `rename {t} ke {t2}`, …; `{t2}` is the text
+list shifted by 7 like `{f2}`), 20 fills × 14 phrasings. `pool_v10` =
+`head.py pool_v7` + `lists.py` with the new block: 235,159 rows; every
+row that is not `mv` is byte-identical to pool_v9 in the same order; `mv`
+resampled under the same budget (500 tasks, seed 42) — 236 rename rows in,
+253 other mv head rows out.
+
+**Run 12, hypothesis before the run (owner: retrain, 2026-08-18).**
+`qwen-v10` = pool_v10, one variable vs run 11 (the mv resample), then
+`qwen-v10-dpo` on its own probe misses, same chain as runs 10/11.
+Hypothesis: `#51 exact` 8/8 on v10-dpo (the rename shape now has rows to
+imitate); every other probe number within run 11's ±3 churn (basics 171,
+holdout 29, `delete file` still broken — nothing here touches it); ALFA
+inside the CI vs shipped on every register. Falsified if the rename
+prompt still comes back translated — then 236 rows are not enough weight
+against the prior and the lever is DPO pairs on exactly that shape, not
+more SFT rows. Ship rule unchanged: the README quoting workaround comes
+out only when a shipped model shows 8/8.

--- a/dataset/basics_head.txt
+++ b/dataset/basics_head.txt
@@ -1,6 +1,6 @@
 # Head rows for the beginner verbs (issue #62). Same block format as
 # basics.txt, read by head.py, plus slots that head.py fills twenty ways:
-#   {t} text file   {f} any file   {f2} another file   {d} folder   {d2} another
+#   {t} text file   {t2} another   {f} any file   {f2} another file   {d} folder   {d2} another
 #   {u} user  {h} host  {n} count  {pid} PID  {port}  {sshport}  {p} process
 #   {z} zip  {url}  {log} log file
 # A phrasing must carry every slot its cmd carries. No path/to. Probe
@@ -321,6 +321,12 @@ F: Namakan semula direktori {d} sebagai {d2} | Tukar nama folder {d} kepada {d2}
 C: nak tukar nama folder {d} jadi {d2} | rename folder {d} ke {d2} | tolong tukar nama direktori {d} kepada {d2}
 R: nak rename folder {d} to {d2} | tukar nama folder {d} jadi {d2} | rename directory {d} as {d2}
 E: rename the folder {d} to {d2} | change the directory name {d} to {d2}
+
+cmd: mv {t} {t2}
+F: Namakan semula fail {t} sebagai {t2} | Tukar nama fail {t} kepada {t2}
+C: nak tukar nama fail {t} jadi {t2} | rename {t} ke {t2} | nak rename fail {t} jadi {t2} | tolong tukar nama {t} kepada {t2} | tukar nama file {t} jadi {t2}
+R: nak rename file {t} to {t2} | rename {t} jadi {t2} | tukar nama {t} to {t2} | nak rename fail {t} jadi {t2} boleh?
+E: rename {t} to {t2} | change the file name {t} to {t2} | rename the file {t} as {t2}
 
 cmd: mv {t} {t}.old
 F: Namakan semula fail {t} sebagai {t}.old

--- a/dataset/head.py
+++ b/dataset/head.py
@@ -87,14 +87,14 @@ NAMES = {
 }
 K = 20
 assert all(len(v) == K for v in NAMES.values())
-SLOT = re.compile(r"\{(t|f2|f|d2|d|u|h|n|pid|sshport|port|p|z|url|log)\}")
+SLOT = re.compile(r"\{(t2|t|f2|f|d2|d|u|h|n|pid|sshport|port|p|z|url|log)\}")
 
 
 def fill(text, k):
-    """Slot k of every list; `{f2}`/`{d2}` are the same lists shifted by 7."""
+    """Slot k of every list; `{t2}`/`{f2}`/`{d2}` are the same lists shifted by 7."""
     def one(m):
         s = m.group(1)
-        return NAMES[s[0]][(k + 7) % K] if s in ("f2", "d2") else NAMES[s][k % K]
+        return NAMES[s[0]][(k + 7) % K] if s in ("t2", "f2", "d2") else NAMES[s][k % K]
     return SLOT.sub(one, text)
 
 

--- a/dataset/head.py
+++ b/dataset/head.py
@@ -51,7 +51,7 @@ HOLDOUT = {"truncate", "tac", "whereis", "dirname", "tee", "timeout", "chsh",
            "printenv", "nl"}
 
 NAMES = {
-    "t": "notes.txt nota.txt lama.txt laporan.txt senarai.txt surat.txt jadual.csv "
+    "t": "baru.txt nota.txt lama.txt laporan.txt senarai.txt surat.txt jadual.csv "
          "data.csv todo.md catatan.md draf.txt minit.txt ucapan.txt config.yaml "
          "index.html main.py skrip.sh output.log error.log resit.txt".split(),
     "f": "laporan.pdf gambar.jpg nota.txt lama.txt foto.png resume.docx senarai.txt "

--- a/dataset/test_pipeline.py
+++ b/dataset/test_pipeline.py
@@ -267,6 +267,7 @@ os.unlink(_f.name)
 assert len(_x) == K + 1, len(_x)                       # slotted block x K, plain block x 1
 assert _x[0][1] == "rm laporan.pdf video.mp4" and _x[0][2]["english"] == ["delete laporan.pdf and video.mp4"]
 assert all(cmd.split()[1] != cmd.split()[2] for _, cmd, _ in _x[:K])   # {f} != {f2}
+assert fill("mv {t} {t2}", 2) == "mv lama.txt catatan.md"
 assert _x[K] == ("head:1.0", "free -h", {"formal": ["Paparkan RAM"], "colloquial": ["RAM berapa"],
                                           "rojak": ["check RAM"], "english": ["show RAM"]})
 for bad in ("cmd: rm {f}\nF: Padam fail\nC: buang {f}\nR: delete {f}\nE: delete {f}\n",  # F misses {f}

--- a/training/probe.py
+++ b/training/probe.py
@@ -545,6 +545,20 @@ HOMOGRAPH = [
     ("en-sense", "show only lines where the test failed", r"\b(grep|awk|sed)\b"),
 ]
 
+# Issue #51: a Malay-word filename must come back byte-identical, not
+# translated (`lama.txt` -> `old.txt`). Exact match on the whole line, the
+# one place this probe is stricter than tool-level.
+EXACT = [
+    ("nak delete lama.txt", "rm lama.txt"),
+    ("nak rename fail baru.txt jadi lama.txt", "mv baru.txt lama.txt"),
+    ("nak tengok isi file nota.txt", "cat nota.txt"),
+    ("nak delete file 'lama.txt'", "rm lama.txt"),
+    ("nak copy laporan.pdf ke folder kerja", "cp laporan.pdf kerja/"),
+    ("nak buang fail gambar_lama.jpg", "rm gambar_lama.jpg"),
+    ("nak buat folder projek_baru", "mkdir projek_baru"),
+    ("delete senarai_beli.txt", "rm senarai_beli.txt"),
+]
+
 
 RETRIEVE = 0  # --retrieve K: prepend K tldr lines (retrieve.py) to the user turn
 
@@ -609,14 +623,19 @@ def main():
         train |= {r["nl"].lower() for r in head_rows(os.path.join(dataset, "basics_head.txt"))}
         leaked = [p for t in TASKS + HOLDOUT for p in t["p"].values()
                   if p.lower() in train]
+        leaked += [p for p, _ in EXACT if p.lower() in train]
         if leaked:
             raise SystemExit(f"probe prompts present in basics*.txt: {leaked}")
 
     if args.rescore:
         okre = {t["task"]: t["ok"] for t in TASKS + HOLDOUT}
         okre.update({("homograph", p): r for _, p, r in HOMOGRAPH})
+        exact = dict(EXACT)
         rows = [json.loads(l) for l in open(args.rescore, encoding="utf-8")]
         for r in rows:
+            if r["task"] == "exact":
+                r["ok"] = r["got"] == exact[r["prompt"]]
+                continue
             pat = okre[("homograph", r["prompt"])] if r["task"] == "homograph" else okre[r["task"]]
             r["ok"] = bool(re.search(pat, r["got"]))
         report(rows)
@@ -645,6 +664,10 @@ def main():
             got = ask(prompt)
             rows.append({"task": "homograph", "axis": axis, "prompt": prompt,
                          "got": got, "ok": bool(re.search(ok_re, got))})
+        for prompt, want in EXACT:
+            got = ask(prompt)
+            rows.append({"task": "exact", "axis": "#51", "prompt": prompt,
+                         "got": got, "ok": got == want})
     finally:
         proc.send_signal(signal.SIGTERM)
         proc.wait(timeout=30)
@@ -680,7 +703,7 @@ def report(rows):
     print(f"\n{len(rows)} prompts, tool-level scoring\n")
     fam = {}
     for r in rows:
-        if r["task"] == "homograph" or r["task"].startswith("holdout"):
+        if r["task"] in ("homograph", "exact") or r["task"].startswith("holdout"):
             continue
         f_ = family(r["axis"])
         fam.setdefault(f_, []).append(r["ok"])
@@ -690,7 +713,7 @@ def report(rows):
 
     ho = [r["ok"] for r in rows if r["task"].startswith("holdout")]
     seen = [r["ok"] for r in rows
-            if r["task"] != "homograph" and not r["task"].startswith("holdout")]
+            if r["task"] not in ("homograph", "exact") and not r["task"].startswith("holdout")]
     print(f"\n{'basics tasks':12s} {sum(seen)/len(seen):8.2f}  {len(seen)}   (tasks in basics.txt, phrasings not)")
     print(f"{'holdout':12s} {sum(ho)/len(ho):8.2f}  {len(ho)}   (tools absent from basics.txt)")
 
@@ -701,6 +724,9 @@ def report(rows):
     print(f"\nhomograph guard")
     for a, v in sorted(hom.items()):
         print(f"{a:12s} {sum(v)/len(v):8.2f}  {len(v)}")
+    ex = [r["ok"] for r in rows if r["task"] == "exact"]
+    if ex:
+        print(f"\n#51 exact     {sum(ex)}/{len(ex)}   (Malay filename byte-identical)")
 
     print("\nfailures:")
     for r in rows:


### PR DESCRIPTION
Addresses #51 on the data side; not a model ship.

## What
- `dataset/basics_head.txt`: `mv {t} {t2}` file-rename block; `{t2}` slot in `head.py` (text list shifted by 7, like `{f2}`); `baru.txt` replaces `notes.txt` in the `{t}` list.
- `training/probe.py`: `EXACT` section — eight whole-line prompts (`nak delete lama.txt` → `rm lama.txt`), printed as `#51 exact n/8`, covered by the basics leak check.
- `RESULTS.md`: "Issue #51" section, runs 12 and 13.

## Numbers
| model | #51 exact | BM ALFA vs shipped |
|---|---|---|
| shipped v0.9.0 | 2/8 | — |
| qwen-v9-dpo (run 11) | 7/8 | −0.020, inside CI |
| qwen-v10-dpo (run 12, rename block) | 7/8 | −0.043 [−0.097, +0.011] |
| qwen-v11-dpo (run 13, + baru.txt) | **8/8** | **−0.073 [−0.125, −0.022]**, p = 0.008 |

The issue's hypothesis (translated `lama.txt`/`old.txt` pairs in the pool) is falsified — zero such rows; the mapping is the base prior, and head rows with Malay names on both sides beat it. The one prompt that survived was `baru.txt`, a name in zero pool rows.

## Why no ship
v11-dpo BM is below v0.9.0 with the CI clear of zero — the head-row family drifted 0.497 → 0.423 one inside-CI step at a time. Details in RESULTS.md. The data fix ships with the next model that clears ALFA; README workaround stays until then.

pool_v10 / pool_v11 rebuilt from pool_v7 with `head.py` + `lists.py`; every non-`mv` row byte-identical to pool_v9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)